### PR TITLE
Refactor: vervang titel-check door MID-check bij openen zoekresultaat

### DIFF
--- a/poms-functional-tests-fitnesse/src/main/java/nl/specialisterren/fitnesse/fixture/slim/ExtendedStringFixture.java
+++ b/poms-functional-tests-fitnesse/src/main/java/nl/specialisterren/fitnesse/fixture/slim/ExtendedStringFixture.java
@@ -24,4 +24,8 @@ public class ExtendedStringFixture {
 	protected Matcher getMatcher(String regEx, String value) {
         return Pattern.compile(regEx, Pattern.DOTALL).matcher(value);
     }
+
+    public boolean stringStartsWith(String haystack, String needle) {
+	    return haystack.startsWith(needle);
+    }
 }

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/Hoofdscherm.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/Hoofdscherm.wiki
@@ -29,6 +29,11 @@
 |scenario        |Npo poms Hoofdscherm Wacht tot titel van laatste tab                       |titel                       |
 |wait for visible|xpath=//ul[@class="nav nav-tabs"]/li[last()-1]//span[@class="tab-title" and normalize-space(.)="@titel"]|
 
+|scenario              |Npo poms Hoofdscherm Check titel van laatste tab begint met|titel                                                                                                                |
+|seconds before timeout|3                                                                                                                                                                                |
+|ensure                |is visible on page                                         |xpath=//ul[@class="nav nav-tabs"]/li[last()-1]//span[@class="tab-title" and starts-with(normalize-space(.),"@titel")]|
+|seconds before timeout|${secondsBeforeTimeout}                                                                                                                                                          |
+
 |scenario             |Npo poms Hoofdscherm Check subtitel van laatste tab|subtitel                                                                                        |
 |$subtitelInUpperCase=|convert to upper case                              |@subtitel                                                                  |                    |
 |check                |value of                                           |xpath=//ul[@class="nav nav-tabs"]/li[last()-1]//span[@class="tab-subtitle"]|$subtitelInUpperCase|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/TabbladObject.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/TabbladObject.wiki
@@ -5,6 +5,9 @@
 |scenario|Npo poms Tabblad object Open|object|
 |open    |${UrlPoms}/#/edit/@object          |
 
+|scenario|Npo poms Tabblad object Sla hoofdtitel op in var|var                              |
+|$@var=  |value of                                        |xpath=//h1[@class="viewer-title"]|
+
 |scenario|Npo poms Tabblad object Check hoofdtitel|hoofdtitel                                                    |
 |check   |value of                                |xpath=//span[@class="media breadcrumb-link-title"]|@hoofdtitel|
 |check   |value of                                |xpath=//h1[@class="viewer-title"]                 |@hoofdtitel|
@@ -79,6 +82,9 @@
 
 |scenario|Npo poms Tabblad object Sla mid of urn op in var|var                                                                               |
 |$@var=  |value of                                        |xpath=//h2[normalize-space(.)="Mid Urn"]/following-sibling::p/poms-clipboard/input|
+
+|scenario        |Npo poms Tabblad object Wacht tot tabblad met mid|mid|geopend is|
+|wait for visible|css=.tab-pane.active [id="media-general-@mid"]                  |
 
 |scenario|Npo poms Tabblad object Maak tekstveld|tekstveld|leeg|
 |clear   |@tekstveld                                           |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/Zoeken.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/ScenarioLibrary/NpoPoms/Zoeken.wiki
@@ -43,6 +43,9 @@
 |scenario                                 |Npo poms Zoeken Sla mid bij eerste object op in var|var           |
 |Npo poms Zoeken Sla mid bij object nummer|1                                                  |op in var|@var|
 
+|scenario|Npo poms Zoeken Sla mid bij object nummer|index  |op in var|var    |via attribuutwaarde   |
+|$@var=  |value of attribute                       |data-id|on       |xpath=//table/tbody/tr[@index]|
+
 |scenario        |Npo poms Zoeken Wacht tot status bij object                          |objectNaam                         |met mediatype                         |mediatype                         |bevat                         |statusTekst                         |
 |wait for visible|xpath=//table/tbody/tr[./td[@class="column-title"]/span/span[normalize-space(.)="@objectNaam"]][./td[@class="column-type"]/span/span[normalize-space(.)="@mediatype"]][./td[@class="column-workflow" and contains(normalize-space(.), "@statusTekst")]]|
 
@@ -69,6 +72,21 @@
 
 |scenario                                                  |Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object|
 |Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|1                                                         |
+
+|scenario                                                   |Npo poms Zoeken Open object nummer|index                                              |
+|Npo poms Zoeken Scroll naar object nummer                  |@index                                                                                |
+|Npo poms Zoeken Sla mid bij object nummer                  |@index                            |op in var   |mid        |via attribuutwaarde       |
+|Npo poms Zoeken Sla hoofdtitel van object nummer           |@index                            |op in var   |zoektitelVanObject                    |
+|Npo poms Zoeken Sla type van object nummer                 |@index                            |op in var   |typeVanObject                         |
+|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer |@index                                                                                |
+|Npo poms Tabblad object Wacht tot tabblad met mid          |$mid                              |geopend is                                         |
+|$paginaTitel=                                              |page title                                                                            |
+|ensure                                                     |string                            |$paginaTitel|starts with|POMS - $zoektitelVanObject|
+|Npo poms Hoofdscherm Check titel van laatste tab begint met|$zoektitelVanObject                                                                   |
+|Npo poms Hoofdscherm Check subtitel van laatste tab        |$typeVanObject                                                                        |
+
+|scenario                          |Npo poms Zoeken Open eerste object|
+|Npo poms Zoeken Open object nummer|1                                 |
 
 |scenario        |Npo poms Zoeken Check optie|optie                    |geselecteerd in dropdown                    |dropdown                   |
 |wait for visible|xpath=.//span[normalize-space(.)="@dropdown"]/../following-sibling::*                                                         |
@@ -159,7 +177,7 @@
 |scenario    |Npo poms zoeken Selecteer eerste uitzending                          |
 |double click|xpath=(//h1[contains(text(),"Uitzendingen")]/following::tbody//td)[1]|
 
-|scenario |Npo poms zoeken Scroll naar object nummer|nummer|
+|scenario |Npo poms Zoeken Scroll naar object nummer|nummer|
 |scroll to|xpath=//table/tbody/tr[@nummer]                 |
 
 |scenario|Npo poms Zoeken Check checkbox aangevinkt bij object nummer|index                   |in zoekresultaten                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/CmsSelector/NpoTa78-SpomsCmsSelector1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/CmsSelector/NpoTa78-SpomsCmsSelector1.wiki
@@ -12,19 +12,19 @@ Test
 
 *!
 
-|script                                                                                     |
-|open                                               |${UrlPoms}/${affixCmsSelector}         |
-|click                                              |Select                                 |
-|switch to next tab                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                        |
-|Npo poms Zoeken Selecteer optie                    |${mediatype}|in dropdown |!-MediaType-!|
-|wait for visible                                   |Gezocht naar: ${mediatype}             |
-|Npo poms Zoeken Druk op tandwieltje                                                        |
-|set search context to                              |xpath=//poms-search-columns            |
-|click                                              |${kolomMid}                            |
-|clear search context                                                                       |
-|Npo poms Zoeken Druk op tandwieltje                                                        |
-|Npo poms Zoeken Sla mid bij eerste object op in var|mid                                    |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                 |
-|switch to previous tab                                                                     |
-|Check tekstveld                                    |Result:     |heeft waarde|$mid         |
+|script                                                                                          |
+|open                                                    |${UrlPoms}/${affixCmsSelector}         |
+|click                                                   |Select                                 |
+|switch to next tab                                                                              |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                             |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}|in dropdown |!-MediaType-!|
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}|klaar is                  |
+|Npo poms Zoeken Druk op tandwieltje                                                             |
+|set search context to                                   |xpath=//poms-search-columns            |
+|click                                                   |${kolomMid}                            |
+|clear search context                                                                            |
+|Npo poms Zoeken Druk op tandwieltje                                                             |
+|Npo poms Zoeken Sla mid bij eerste object op in var     |mid                                    |
+|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                      |
+|switch to previous tab                                                                          |
+|Check tekstveld                                         |Result:     |heeft waarde|$mid         |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Gids/NpoTa64-SpomsGids5.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Gids/NpoTa64-SpomsGids5.wiki
@@ -11,18 +11,13 @@ Test
 |script                              |
 |$today=|store|!today (dd-MM-yyyy) -7|
 
-|script                                                                                                                                          |
-|Open Npo poms website                                                                                                                           |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                             |
-|click                                                     |Datum & Persoon                                                                      |
-|Npo poms Zoeken Vul                                       |$today                                          |in tekstveld        |van:           |
-|Npo poms Zoeken Klik op                                   |Zoek                                            |in geopende dropdown|Datum & Persoon|
-|Npo poms Zoeken Selecteer optie                           |Nederland 1                                     |in dropdown         |Zenders        |
-|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:  |Nederland 1, uitzend-/sorteerdatum: vanaf $today|klaar is                            |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |${objectNummer}                                 |op in var           |titelVanObject |
-|Npo poms Zoeken Sla type van object nummer                |${objectNummer}                                 |op in var           |typeVanObject  |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|${objectNummer}                                                                      |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject                                 |geopend                             |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                                      |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                                       |
-|Npo poms Hoofdscherm Log uit                                                                                                                    |
+|script                                                                                                                                        |
+|Open Npo poms website                                                                                                                         |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                           |
+|click                                                   |Datum & Persoon                                                                      |
+|Npo poms Zoeken Vul                                     |$today                                          |in tekstveld        |van:           |
+|Npo poms Zoeken Klik op                                 |Zoek                                            |in geopende dropdown|Datum & Persoon|
+|Npo poms Zoeken Selecteer optie                         |Nederland 1                                     |in dropdown         |Zenders        |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Nederland 1, uitzend-/sorteerdatum: vanaf $today|klaar is                            |
+|Npo poms Zoeken Open object nummer                      |${objectNummer}                                                                      |
+|Npo poms Hoofdscherm Log uit                                                                                                                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/ImageUpload/NpoTa44-SpomsImageUpload1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/ImageUpload/NpoTa44-SpomsImageUpload1.wiki
@@ -9,13 +9,8 @@ Test
 |Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                    |
 |Npo poms Zoeken Selecteer optie                                                  |Clip           |in dropdown |!-MediaType-!           |
 |Npo poms Zoeken Selecteer optie                                                  |VPRO           |in dropdown |Omroepen                |
-|wait for visible                                                                 |Gezocht naar: Clip, VPRO                             |
-|Npo poms Zoeken Sla hoofdtitel van object nummer                                 |${objectNummer}|op in var   |titelVanObject          |
-|Npo poms Zoeken Sla type van object nummer                                       |${objectNummer}|op in var   |typeVanObject           |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer                       |${objectNummer}                                      |
-|Npo poms Hoofdscherm Wacht tot tabblad                                           |$titelVanObject|geopend                              |
-|Npo poms Hoofdscherm Check titel van laatste tab                                 |$titelVanObject                                      |
-|Npo poms Hoofdscherm Check subtitel van laatste tab                              |$typeVanObject                                       |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:                         |Clip, VPRO     |klaar is                             |
+|Npo poms Zoeken Open object nummer                                               |${objectNummer}                                      |
 |Npo poms Tabblad object Druk op link                                             |Afbeeldingen   |in sidebar                           |
 |wait for visible                                                                 |Afbeelding toevoegen                                 |
 |set search context to                                                            |xpath=//poms-images                                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/ImageUpload/SmallScenarioLibrary.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/ImageUpload/SmallScenarioLibrary.wiki
@@ -10,36 +10,31 @@
 |hover over        |@afbeelding1                                                                                                                                                                                                                               |
 |dragAndDropFromTo;|//tbody[@ui-sortable='sortableOptions']/descendant::span[normalize-space(.)='@afbeelding1']/preceding::span[@class='sort-handle'][1]|//tbody[@ui-sortable='sortableOptions']/descendant::span[normalize-space(.)='@afbeelding2']/parent::td|
 
-|scenario                              |Zoek clip met titel en mediatype en omroep _|titel, mediatype, omroep                 |
-|scroll to                             |!-MediaType-!                                                                         |
-|Npo poms Zoeken Selecteer optie       |@mediatype                                  |zonder controle in dropdown|!-MediaType-!|
-|scroll to                             |!-Omroepen-!                                                                          |
-|Npo poms Zoeken Selecteer optie       |@omroep                                     |zonder controle in dropdown|!-Omroepen-! |
-|wait for visible                      |Gezocht naar: @mediatype, @omroep                                                     |
-|scroll to                             |xpath=//input[@id='query']                                                            |
-|Npo poms Zoeken Vul                   |@titel                                      |in zoekveld                              |
-|Npo poms Zoeken Druk knop             |Zoeken                                                                                |
-|double click                          |@titel                                                                                |
-|Npo poms Hoofdscherm Wacht tot tabblad|@titel                                      |geopend                                  |
-|Npo poms Tabblad object Druk op link  |Afbeeldingen                                |in sidebar                               |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                          |
+|scenario                                                |Zoek clip met titel en mediatype en omroep _|titel, mediatype, omroep                 |
+|scroll to                                               |!-MediaType-!                                                                         |
+|Npo poms Zoeken Selecteer optie                         |@mediatype                                  |zonder controle in dropdown|!-MediaType-!|
+|scroll to                                               |!-Omroepen-!                                                                          |
+|Npo poms Zoeken Selecteer optie                         |@omroep                                     |zonder controle in dropdown|!-Omroepen-! |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|@mediatype, @omroep                         |klaar is                                 |
+|Npo poms Zoeken Scroll naar zoekveld                                                                                                           |
+|Npo poms Zoeken Vul                                     |@titel                                      |in zoekveld                              |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                |
+|double click                                            |@titel                                                                                |
+|Npo poms Hoofdscherm Wacht tot tabblad                  |@titel                                      |geopend                                  |
+|Npo poms Tabblad object Druk op link                    |Afbeeldingen                                |in sidebar                               |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                            |
 
 
-|scenario                                                  |Zoek clip met objectnummer|nummer                     |en druk op link afbeelding toevoegen|
-|scroll to                                                 |!-MediaType-!                                                                              |
-|Npo poms Zoeken Selecteer optie                           |Clip                      |zonder controle in dropdown|!-MediaType-!                       |
-|scroll to                                                 |!-Omroepen-!                                                                               |
-|Npo poms Zoeken Selecteer optie                           |VPRO                      |zonder controle in dropdown|!-Omroepen-!                        |
-|wait for visible                                          |Gezocht naar: Clip, VPRO                                                                   |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |@nummer                   |op in var                  |titelVanObject                      |
-|Npo poms Zoeken Sla type van object nummer                |@nummer                   |op in var                  |typeVanObject                       |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|@nummer                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject           |geopend                                                         |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                                            |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                                             |
-|Npo poms Tabblad object Sla mid of urn op in var          |mid                                                                                        |
-|Npo poms Tabblad object Druk op link                      |Afbeeldingen              |in sidebar                                                      |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                   |
+|scenario                                                |Zoek clip met objectnummer|nummer                     |en druk op link afbeelding toevoegen|
+|scroll to                                               |!-MediaType-!                                                                              |
+|Npo poms Zoeken Selecteer optie                         |Clip                      |zonder controle in dropdown|!-MediaType-!                       |
+|scroll to                                               |!-Omroepen-!                                                                               |
+|Npo poms Zoeken Selecteer optie                         |VPRO                      |zonder controle in dropdown|!-Omroepen-!                        |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Clip, VPRO                |klaar is                                                        |
+|Npo poms Zoeken Open object nummer                      |@nummer                                                                                    |
+|Npo poms Tabblad object Sla mid of urn op in var        |mid                                                                                        |
+|Npo poms Tabblad object Druk op link                    |Afbeeldingen              |in sidebar                                                      |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                 |
 
 
 |scenario                                            |Voeg afbeelding met titel|titel                              |toe aan clip                |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NPOS/NpoTa80-SpomsNpos1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NPOS/NpoTa80-SpomsNpos1.wiki
@@ -2,41 +2,35 @@
 Suites: MT
 Test
 ---
-|script                                                                                                                      |
-|Open Npo poms website                                                                                                       |
-|Npo poms Inlogscherm Log in met npo                                                                                         |
-|click                                                                            |ZOEKEN                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad Zoeken geopend                                                                       |
-|Npo poms Zoeken Selecteer optie                                                  |Nederland 2       |in dropdown|Zenders    |
-|Npo poms Zoeken Druk knop                                                        |Zoeken                                    |
-|wait for visible                                                                 |Gezocht naar: Nederland 2                 |
-|Npo poms zoeken Scroll naar object nummer                                        |10                                        |
-|Npo poms Zoeken Sla hoofdtitel van object nummer                                 |10                |op in var  |titelObject|
-|Npo poms Zoeken Sla type van object nummer                                       |10                |op in var  |typeObject |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer                       |10                                        |
-|Npo poms Hoofdscherm Wacht tot tabblad                                           |$titelObject      |geopend                |
-|Npo poms Hoofdscherm Check titel van laatste tab                                 |$titelObject                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab                              |$typeObject                               |
-|Npo poms zoeken Klik op uitzendingen in linkermenu                                                                          |
-|Npo poms zoeken Selecteer eerste uitzending                                                                                 |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid dropdown met titel  |Kanaal:                                   |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid dropdown met titel  |Net:                                      |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Starttijd:                                |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Stoptijd:                                 |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Titel                                     |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Afleveringtitel / Subtitel                |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Korte titel                               |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Afkorting                                 |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Werktitel                                 |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Originele titel                           |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Beschrijving                              |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Korte beschrijving                        |
-|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Eenregelige beschrijving                  |
-|ensure                                                                           |is visible on page|Bewaar                 |
-|ensure                                                                           |is visible on page|Annuleer               |
-|ensure                                                                           |is visible on page|Gidsdatum:             |
-|ensure                                                                           |is visible on page|Teletekstpagina:       |
-|ensure                                                                           |is visible on page|Ondertiteling:         |
-|ensure                                                                           |is visible on page|Herhaling:             |
-|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten                                                   |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                      |
+|script                                                                                                                  |
+|Open Npo poms website                                                                                                   |
+|Npo poms Inlogscherm Log in met npo                                                                                     |
+|click                                                                            |ZOEKEN                                |
+|Npo poms Hoofdscherm Wacht tot tabblad Zoeken geopend                                                                   |
+|Npo poms Zoeken Selecteer optie                                                  |Nederland 2       |in dropdown|Zenders|
+|Npo poms Zoeken Druk knop                                                        |Zoeken                                |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:                         |Nederland 2       |klaar is           |
+|Npo poms Zoeken Open object nummer                                               |10                                    |
+|Npo poms zoeken Klik op uitzendingen in linkermenu                                                                      |
+|Npo poms zoeken Selecteer eerste uitzending                                                                             |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid dropdown met titel  |Kanaal:                               |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid dropdown met titel  |Net:                                  |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Starttijd:                            |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Stoptijd:                             |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Titel                                 |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Afleveringtitel / Subtitel            |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Korte titel                           |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Afkorting                             |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Werktitel                             |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid input veld met titel|Originele titel                       |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Beschrijving                          |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Korte beschrijving                    |
+|Npo poms Tabblad object Detailscherm controleer aanwezigheid textarea met titel  |Eenregelige beschrijving              |
+|ensure                                                                           |is visible on page|Bewaar             |
+|ensure                                                                           |is visible on page|Annuleer           |
+|ensure                                                                           |is visible on page|Gidsdatum:         |
+|ensure                                                                           |is visible on page|Teletekstpagina:   |
+|ensure                                                                           |is visible on page|Ondertiteling:     |
+|ensure                                                                           |is visible on page|Herhaling:         |
+|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten                                               |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NPOS/NpoTa81-SpomsNpos2.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NPOS/NpoTa81-SpomsNpos2.wiki
@@ -76,29 +76,23 @@ Test
 *!
 
 
-|script                                                                                         |
-|Open Npo poms website                                                                          |
-|Npo poms Inlogscherm Log in met admin                                                          |
-|click                                                     |ZOEKEN                              |
-|Npo poms Hoofdscherm Wacht tot tabblad Zoeken geopend                                          |
-|Npo poms Zoeken Selecteer optie                           |Nederland 2 |in dropdown|Zenders    |
-|Npo poms Zoeken Druk knop                                 |Zoeken                              |
-|wait for visible                                          |Gezocht naar: Nederland 2           |
-|Npo poms zoeken Scroll naar object nummer                 |10                                  |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |10          |op in var  |titelObject|
-|Npo poms Zoeken Sla type van object nummer                |10          |op in var  |typeObject |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|10                                  |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelObject|geopend                |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelObject                        |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeObject                         |
-|Npo poms zoeken Klik op uitzendingen in linkermenu                                             |
-|Npo poms zoeken Selecteer eerste uitzending                                                    |
-|Sla huidige waardes uit Detailscherm op                                                        |
-|Vul nieuwe waardes in in het detailscherm                                                      |
-|click                                                     |Bewaar                              |
-|wait for visible                                          |is nu Wordt gepubliceerd            |
-|Npo poms zoeken Selecteer eerste uitzending                                                    |
-|Controleer de nieuwe waardes in detailscherm                                                   |
-|Zet originele waardes terug in het detailscherm                                                |
-|click                                                     |Bewaar                              |
-|Npo poms Hoofdscherm Sluit laatste tab                                                         |
+|script                                                                                  |
+|Open Npo poms website                                                                   |
+|Npo poms Inlogscherm Log in met admin                                                   |
+|click                                                   |ZOEKEN                         |
+|Npo poms Hoofdscherm Wacht tot tabblad Zoeken geopend                                   |
+|Npo poms Zoeken Selecteer optie                         |Nederland 2|in dropdown|Zenders|
+|Npo poms Zoeken Druk knop                               |Zoeken                         |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Nederland 2|klaar is           |
+|Npo poms Zoeken Open object nummer                      |10                             |
+|Npo poms zoeken Klik op uitzendingen in linkermenu                                      |
+|Npo poms zoeken Selecteer eerste uitzending                                             |
+|Sla huidige waardes uit Detailscherm op                                                 |
+|Vul nieuwe waardes in in het detailscherm                                               |
+|click                                                   |Bewaar                         |
+|wait for visible                                        |is nu Wordt gepubliceerd       |
+|Npo poms zoeken Selecteer eerste uitzending                                             |
+|Controleer de nieuwe waardes in detailscherm                                            |
+|Zet originele waardes terug in het detailscherm                                         |
+|click                                                   |Bewaar                         |
+|Npo poms Hoofdscherm Sluit laatste tab                                                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa23-SpomsNpo3.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa23-SpomsNpo3.wiki
@@ -13,53 +13,44 @@ Test
 
 *!
 
-|script                                                                                                          |
-|Open Npo poms website                                                                                           |
-|Npo poms Inlogscherm Log in met npo                                                                             |
-|Npo poms Zoeken Selecteer optie                           |${mediatype1}  |in dropdown           |!-MediaType-! |
-|Npo poms Zoeken Selecteer optie                           |${criteria1}   |in dropdown           |Criteria      |
-|Npo poms Zoeken Selecteer optie                           |${avType}      |in dropdown           |!-avType-!    |
-|wait for visible                                          |Gezocht naar: ${mediatype1}, ${avType}, ${criteria1} |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |${objectNummer}|op in var             |titelVanObject|
-|Npo poms Zoeken Sla type van object nummer                |${objectNummer}|op in var             |typeVanObject |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|${objectNummer}                                      |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject|geopend                              |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                      |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                       |
-|Npo poms Tabblad object Sla mid of urn op in var          |mid                                                  |
-|click                                                     |Type                                                 |
-|set search context to                                     |xpath=//span[@class="editable-controls"]             |
-|click                                                     |${mediatype2}                                        |
-|click                                                     |save                                                 |
-|clear search context                                                                                            |
-|wait for not visible                                      |save                                                 |
-|Npo poms Tabblad object Check veldtype 2                  |Type           |heeft waarde          |${mediatype2} |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Zoeken Selecteer optie                           |${mediatype1}  |in dropdown           |!-MediaType-! |
-|Npo poms Zoeken Selecteer optie                           |${criteria1}   |in dropdown           |Criteria      |
-|Npo poms Zoeken Selecteer optie                           |${avType}      |in dropdown           |!-avType-!    |
-|wait for visible                                          |Gezocht naar: ${mediatype1}, ${avType}, ${criteria1} |
-|$aantalZoekresultaten2=                                   |subtract       |$aantalZoekresultaten1|and     |1    |
-|Npo poms Zoeken Check aantal zoekresultaten               |$aantalZoekresultaten2                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Zoeken Vul                                       |$mid           |in zoekveld                          |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                               |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                                       |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                                        |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                      |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject|geopend                              |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                      |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                       |
-|click                                                     |Type                                                 |
-|set search context to                                     |xpath=//span[@class="editable-controls"]             |
-|click                                                     |${mediatype1}                                        |
-|click                                                     |save                                                 |
-|clear search context                                                                                            |
-|wait for not visible                                      |save                                                 |
-|Npo poms Tabblad object Check veldtype 2                  |Type           |heeft waarde          |${mediatype1} |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                          |
-|Npo poms Hoofdscherm Log uit                                                                                    |
+|script                                                                                                                              |
+|Open Npo poms website                                                                                                               |
+|Npo poms Inlogscherm Log in met npo                                                                                                 |
+|Npo poms Zoeken Selecteer optie                         |${mediatype1}                         |in dropdown           |!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${criteria1}                          |in dropdown           |Criteria     |
+|Npo poms Zoeken Selecteer optie                         |${avType}                             |in dropdown           |!-avType-!   |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype1}, ${avType}, ${criteria1}|klaar is                            |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                      |
+|Npo poms Zoeken Open object nummer                      |${objectNummer}                                                            |
+|Npo poms Tabblad object Sla mid of urn op in var        |mid                                                                        |
+|click                                                   |Type                                                                       |
+|set search context to                                   |xpath=//span[@class="editable-controls"]                                   |
+|click                                                   |${mediatype2}                                                              |
+|click                                                   |save                                                                       |
+|clear search context                                                                                                                |
+|wait for not visible                                    |save                                                                       |
+|Npo poms Tabblad object Check veldtype 2                |Type                                  |heeft waarde          |${mediatype2}|
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Zoeken Selecteer optie                         |${mediatype1}                         |in dropdown           |!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${criteria1}                          |in dropdown           |Criteria     |
+|Npo poms Zoeken Selecteer optie                         |${avType}                             |in dropdown           |!-avType-!   |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype1}, ${avType}, ${criteria1}|klaar is                            |
+|$aantalZoekresultaten2=                                 |subtract                              |$aantalZoekresultaten1|and    |1    |
+|Npo poms Zoeken Check aantal zoekresultaten             |$aantalZoekresultaten2                                                     |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Zoeken Vul                                     |$mid                                  |in zoekveld                         |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'$mid'                                |klaar is                            |
+|Npo poms Zoeken Open eerste object                                                                                                  |
+|click                                                   |Type                                                                       |
+|set search context to                                   |xpath=//span[@class="editable-controls"]                                   |
+|click                                                   |${mediatype1}                                                              |
+|click                                                   |save                                                                       |
+|clear search context                                                                                                                |
+|wait for not visible                                    |save                                                                       |
+|Npo poms Tabblad object Check veldtype 2                |Type                                  |heeft waarde          |${mediatype1}|
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Log uit                                                                                                        |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa24-SpomsNpo4.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa24-SpomsNpo4.wiki
@@ -18,96 +18,87 @@ Test
 
 *!
 
-|script                                                                                                                              |
-|Open Npo poms website                                                                                                               |
-|Npo poms Inlogscherm Log in met npo                                                                                                 |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}             |in dropdown     |!-MediaType-!                 |
-|Npo poms Zoeken Selecteer optie                           |${criteria1}             |in dropdown     |Criteria                      |
-|Npo poms Zoeken Selecteer optie                           |${avType}                |in dropdown     |!-avType-!                    |
-|Npo poms Zoeken Selecteer optie                           |${zender1}               |in dropdown     |Zenders                       |
-|wait for visible                                          |Gezocht naar: ${mediatype}, ${zender1}, ${avType}, ${criteria1}          |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |${objectNummer}          |op in var       |titelVanObject                |
-|Npo poms Zoeken Sla type van object nummer                |${objectNummer}          |op in var       |typeVanObject                 |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|${objectNummer}                                                          |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject          |geopend                                        |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                          |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                           |
-|Npo poms Tabblad object Sla veldtype 2                    |Uitzending (1)           |op in var       |uitzending                    |
-|Npo poms Tabblad object Sla mid of urn op in var          |mid                                                                      |
-|Npo poms Tabblad object Druk op link                      |Uitzendingen             |in sidebar                                     |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                 |
-|Npo poms Zoeken Dubbelklik op kanaal                      |${zender1}                                                               |
-|wait for visible                                          |Bewaar                                                                   |
-|Npo poms Tabblad object Detailscherm Selecteer optie      |${zender2}               |in dropdown     |Kanaal:                       |
-|Npo poms Tabblad object Detailscherm Sla datepicker       |Starttijd:               |op in var       |starttijd1                    |
-|$starttijd2=                                              |increase date            |$starttijd1     |with hours         |-1        |
-|Npo poms Tabblad object Detailscherm Sla textarea         |Beschrijving             |op in var       |beschrijving1                 |
-|Npo poms Tabblad object Detailscherm Sla textarea         |Korte beschrijving       |op in var       |korteBeschrijving1            |
-|Npo poms Tabblad object Detailscherm Vul                  |$starttijd2              |in datepicker   |Starttijd:                    |
-|Npo poms Tabblad object Detailscherm Vul                  |${beschrijving2}         |in textarea     |Beschrijving                  |
-|Npo poms Tabblad object Detailscherm Vul                  |${korteBeschrijving2}    |in textarea     |Korte beschrijving            |
-|scroll to                                                 |Originele titel                                                          |
-|Npo poms Tabblad object Detailscherm Sla tekstveld        |Originele titel          |op in var       |origineleTitel1               |
-|Npo poms Tabblad object Detailscherm Vul                  |${origineleTitel2}       |in tekstveld    |Originele titel               |
-|click                                                     |Bewaar                                                                   |
-|wait for not visible                                      |Bewaar                                                                   |
-|Npo poms Tabblad object Druk op link                      |Algemeen                 |in sidebar                                     |
-|wait for visible                                          |Sorteerdatum                                                             |
-|Npo poms Tabblad object Check veldtype 2                  |Uitzending (1)           |heeft waarde    |$starttijd2 (${zender2})      |
-|Npo poms Tabblad object Check veldtype 2                  |Sorteerdatum             |heeft waarde    |$starttijd2                   |
-|Npo poms Tabblad object Druk op link                      |Uitzendingen             |in sidebar                                     |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                 |
-|ensure                                                    |is visible on page       |${zender2}                                     |
-|ensure                                                    |is visible on page       |$starttijd2                                    |
-|Npo poms Zoeken Dubbelklik op kanaal                      |${zender2}                                                               |
-|wait for visible                                          |Bewaar                                                                   |
-|Npo poms Tabblad object Detailscherm Check dropdown       |Kanaal:                  |heeft waarde    |${zender2}                    |
-|Npo poms Tabblad object Detailscherm Check datepicker     |Starttijd:               |heeft waarde    |$starttijd2                   |
-|Npo poms Tabblad object Detailscherm Check textarea       |Beschrijving             |heeft waarde    |${beschrijving2}              |
-|Npo poms Tabblad object Detailscherm Check textarea       |Korte beschrijving       |heeft waarde    |${korteBeschrijving2}         |
-|scroll to                                                 |Originele titel                                                          |
-|Npo poms Tabblad object Detailscherm Check tekstveld      |Originele titel          |heeft waarde    |${origineleTitel2}            |
-|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten                                                           |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Zoeken Vul                                       |$mid                     |in zoekveld                                    |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                   |
-|wait for visible                                          |Gezocht naar: '$mid' in ${mediatype}, ${zender1}, ${avType}, ${criteria1}|
-|Npo poms Zoeken Check aantal zoekresultaten               |0                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Zoeken Vul                                       |$mid                     |in zoekveld                                    |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                   |
-|wait for visible                                          |Gezocht naar: '$mid'                                                     |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                                                           |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                                                            |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                          |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject          |geopend                                        |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                          |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                           |
-|Npo poms Tabblad object Druk op link                      |Uitzendingen             |in sidebar                                     |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                 |
-|Npo poms Zoeken Dubbelklik op kanaal                      |${zender2}                                                               |
-|wait for visible                                          |Bewaar                                                                   |
-|Npo poms Tabblad object Detailscherm Selecteer optie      |${zender1}               |in dropdown     |Kanaal:                       |
-|Npo poms Tabblad object Detailscherm Vul                  |$starttijd1              |in datepicker   |Starttijd:                    |
-|Npo poms Tabblad object Detailscherm Vul                  |$beschrijving1           |in textarea     |Beschrijving                  |
-|Npo poms Tabblad object Detailscherm Vul                  |$korteBeschrijving1      |in textarea     |Korte beschrijving            |
-|scroll to                                                 |Originele titel                                                          |
-|Npo poms Tabblad object Detailscherm Vul                  |$origineleTitel1         |in tekstveld    |Originele titel               |
-|click                                                     |Bewaar                                                                   |
-|wait for not visible                                      |Bewaar                                                                   |
-|Npo poms Tabblad object Druk op link                      |Algemeen                 |in sidebar                                     |
-|wait for visible                                          |Sorteerdatum                                                             |
-|Npo poms Tabblad object Check veldtype 2                  |Uitzending (1)           |heeft waarde    |$uitzending                   |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}             |in dropdown     |!-MediaType-!                 |
-|Npo poms Zoeken Selecteer optie                           |${criteria1}             |in dropdown     |Criteria                      |
-|Npo poms Zoeken Selecteer optie                           |${avType}                |in dropdown     |!-avType-!                    |
-|Npo poms Zoeken Selecteer optie                           |${zender1}               |in dropdown     |Zenders                       |
-|Npo poms Zoeken Vul                                       |$mid                     |in zoekveld                                    |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                   |
-|wait for visible                                          |Gezocht naar: '$mid' in ${mediatype}, ${zender1}, ${avType}, ${criteria1}|
-|Npo poms Zoeken Check aantal zoekresultaten               |1                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
-|Npo poms Hoofdscherm Log uit                                                                                                        |
+|script                                                                                                                                                     |
+|Open Npo poms website                                                                                                                                      |
+|Npo poms Inlogscherm Log in met npo                                                                                                                        |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}                                               |in dropdown  |!-MediaType-!           |
+|Npo poms Zoeken Selecteer optie                         |${criteria1}                                               |in dropdown  |Criteria                |
+|Npo poms Zoeken Selecteer optie                         |${avType}                                                  |in dropdown  |!-avType-!              |
+|Npo poms Zoeken Selecteer optie                         |${zender1}                                                 |in dropdown  |Zenders                 |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${zender1}, ${avType}, ${criteria1}          |klaar is                              |
+|Npo poms Zoeken Open object nummer                      |${objectNummer}                                                                                   |
+|Npo poms Tabblad object Sla veldtype 2                  |Uitzending (1)                                             |op in var    |uitzending              |
+|Npo poms Tabblad object Sla mid of urn op in var        |mid                                                                                               |
+|Npo poms Tabblad object Druk op link                    |Uitzendingen                                               |in sidebar                            |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                        |
+|Npo poms Zoeken Dubbelklik op kanaal                    |${zender1}                                                                                        |
+|wait for visible                                        |Bewaar                                                                                            |
+|Npo poms Tabblad object Detailscherm Selecteer optie    |${zender2}                                                 |in dropdown  |Kanaal:                 |
+|Npo poms Tabblad object Detailscherm Sla datepicker     |Starttijd:                                                 |op in var    |starttijd1              |
+|$starttijd2=                                            |increase date                                              |$starttijd1  |with hours      |-1     |
+|Npo poms Tabblad object Detailscherm Sla textarea       |Beschrijving                                               |op in var    |beschrijving1           |
+|Npo poms Tabblad object Detailscherm Sla textarea       |Korte beschrijving                                         |op in var    |korteBeschrijving1      |
+|Npo poms Tabblad object Detailscherm Vul                |$starttijd2                                                |in datepicker|Starttijd:              |
+|Npo poms Tabblad object Detailscherm Vul                |${beschrijving2}                                           |in textarea  |Beschrijving            |
+|Npo poms Tabblad object Detailscherm Vul                |${korteBeschrijving2}                                      |in textarea  |Korte beschrijving      |
+|scroll to                                               |Originele titel                                                                                   |
+|Npo poms Tabblad object Detailscherm Sla tekstveld      |Originele titel                                            |op in var    |origineleTitel1         |
+|Npo poms Tabblad object Detailscherm Vul                |${origineleTitel2}                                         |in tekstveld |Originele titel         |
+|click                                                   |Bewaar                                                                                            |
+|wait for not visible                                    |Bewaar                                                                                            |
+|Npo poms Tabblad object Druk op link                    |Algemeen                                                   |in sidebar                            |
+|wait for visible                                        |Sorteerdatum                                                                                      |
+|Npo poms Tabblad object Check veldtype 2                |Uitzending (1)                                             |heeft waarde |$starttijd2 (${zender2})|
+|Npo poms Tabblad object Check veldtype 2                |Sorteerdatum                                               |heeft waarde |$starttijd2             |
+|Npo poms Tabblad object Druk op link                    |Uitzendingen                                               |in sidebar                            |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                        |
+|ensure                                                  |is visible on page                                         |${zender2}                            |
+|ensure                                                  |is visible on page                                         |$starttijd2                           |
+|Npo poms Zoeken Dubbelklik op kanaal                    |${zender2}                                                                                        |
+|wait for visible                                        |Bewaar                                                                                            |
+|Npo poms Tabblad object Detailscherm Check dropdown     |Kanaal:                                                    |heeft waarde |${zender2}              |
+|Npo poms Tabblad object Detailscherm Check datepicker   |Starttijd:                                                 |heeft waarde |$starttijd2             |
+|Npo poms Tabblad object Detailscherm Check textarea     |Beschrijving                                               |heeft waarde |${beschrijving2}        |
+|Npo poms Tabblad object Detailscherm Check textarea     |Korte beschrijving                                         |heeft waarde |${korteBeschrijving2}   |
+|scroll to                                               |Originele titel                                                                                   |
+|Npo poms Tabblad object Detailscherm Check tekstveld    |Originele titel                                            |heeft waarde |${origineleTitel2}      |
+|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten                                                                                  |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Zoeken Scroll naar zoekveld                                                                                                                       |
+|Npo poms Zoeken Vul                                     |$mid                                                       |in zoekveld                           |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                            |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'$mid' in ${mediatype}, ${zender1}, ${avType}, ${criteria1}|klaar is                              |
+|Npo poms Zoeken Check aantal zoekresultaten             |0                                                                                                 |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Zoeken Vul                                     |$mid                                                       |in zoekveld                           |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                            |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'$mid'                                                     |klaar is                              |
+|Npo poms Zoeken Open eerste object                                                                                                                         |
+|Npo poms Tabblad object Druk op link                    |Uitzendingen                                               |in sidebar                            |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                        |
+|Npo poms Zoeken Dubbelklik op kanaal                    |${zender2}                                                                                        |
+|wait for visible                                        |Bewaar                                                                                            |
+|Npo poms Tabblad object Detailscherm Selecteer optie    |${zender1}                                                 |in dropdown  |Kanaal:                 |
+|Npo poms Tabblad object Detailscherm Vul                |$starttijd1                                                |in datepicker|Starttijd:              |
+|Npo poms Tabblad object Detailscherm Vul                |$beschrijving1                                             |in textarea  |Beschrijving            |
+|Npo poms Tabblad object Detailscherm Vul                |$korteBeschrijving1                                        |in textarea  |Korte beschrijving      |
+|scroll to                                               |Originele titel                                                                                   |
+|Npo poms Tabblad object Detailscherm Vul                |$origineleTitel1                                           |in tekstveld |Originele titel         |
+|click                                                   |Bewaar                                                                                            |
+|wait for not visible                                    |Bewaar                                                                                            |
+|Npo poms Tabblad object Druk op link                    |Algemeen                                                   |in sidebar                            |
+|wait for visible                                        |Sorteerdatum                                                                                      |
+|Npo poms Tabblad object Check veldtype 2                |Uitzending (1)                                             |heeft waarde |$uitzending             |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}                                               |in dropdown  |!-MediaType-!           |
+|Npo poms Zoeken Selecteer optie                         |${criteria1}                                               |in dropdown  |Criteria                |
+|Npo poms Zoeken Selecteer optie                         |${avType}                                                  |in dropdown  |!-avType-!              |
+|Npo poms Zoeken Selecteer optie                         |${zender1}                                                 |in dropdown  |Zenders                 |
+|Npo poms Zoeken Vul                                     |$mid                                                       |in zoekveld                           |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                            |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'$mid' in ${mediatype}, ${zender1}, ${avType}, ${criteria1}|klaar is                              |
+|Npo poms Zoeken Check aantal zoekresultaten             |1                                                                                                 |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                     |
+|Npo poms Hoofdscherm Log uit                                                                                                                               |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa25-SpomsNpo5.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/NpoGebruiker/NpoTa25-SpomsNpo5.wiki
@@ -11,41 +11,36 @@ Test
 
 *!
 
-|script                                                                                                     |
-|Open Npo poms website                                                                                      |
-|Npo poms Inlogscherm Log in met npo                                                                        |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}     |in dropdown   |!-MediaType-!  |
-|Npo poms Zoeken Selecteer optie                           |${avType}        |in dropdown   |!-avType-!     |
-|Npo poms Zoeken Selecteer optie                           |${omroep}        |in dropdown   |Omroepen       |
-|wait for visible                                          |Gezocht naar: ${mediatype}, ${omroep}, ${avType}|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                                  |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                                   |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                 |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject  |geopend                       |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                 |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                  |
-|Npo poms Tabblad object Sla veldtype 2                    |Sorteerdatum     |op in var     |datum1         |
-|Npo poms Tabblad object Druk op link                      |Platformen       |in sidebar                    |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                        |
-|Npo poms Zoeken Dubbelklik op platform                    |${platform}                                     |
-|wait for visible                                          |Sla op                                          |
-|$datum2=                                                  |store            |!today (dd-MM-yyyy HH:mm)     |
-|Npo poms Tabblad object Detailscherm Vul                  |$datum2          |in tekstveld  |Start          |
-|click                                                     |Sla op                                          |
-|wait for not visible                                      |Sla op                                          |
-|Npo poms Tabblad object Druk op link                      |Algemeen         |in sidebar                    |
-|wait for visible                                          |Sorteerdatum                                    |
-|Npo poms Tabblad object Check veldtype 2                  |Sorteerdatum     |heeft waarde  |$datum2        |
-|Npo poms Tabblad object Druk op link                      |Platformen       |in sidebar                    |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                        |
-|Npo poms Zoeken Dubbelklik op platform                    |${platform}                                     |
-|wait for visible                                          |Sla op                                          |
-|Npo poms Tabblad object Detailscherm Vul                  |$datum1          |in tekstveld  |Start          |
-|click                                                     |Sla op                                          |
-|wait for not visible                                      |Sla op                                          |
-|Npo poms Tabblad object Druk op link                      |Algemeen         |in sidebar                    |
-|wait for visible                                          |Sorteerdatum                                    |
-|Npo poms Tabblad object Check veldtype 2                  |Sorteerdatum     |heeft waarde  |$datum1        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                     |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                     |
-|Npo poms Hoofdscherm Log uit                                                                               |
+|script                                                                                                                |
+|Open Npo poms website                                                                                                 |
+|Npo poms Inlogscherm Log in met npo                                                                                   |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}                      |in dropdown |!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${avType}                         |in dropdown |!-avType-!   |
+|Npo poms Zoeken Selecteer optie                         |${omroep}                         |in dropdown |Omroepen     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep}, ${avType}|klaar is                  |
+|Npo poms Zoeken Open eerste object                                                                                    |
+|Npo poms Tabblad object Sla veldtype 2                  |Sorteerdatum                      |op in var   |datum1       |
+|Npo poms Tabblad object Druk op link                    |Platformen                        |in sidebar                |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                   |
+|Npo poms Zoeken Dubbelklik op platform                  |${platform}                                                  |
+|wait for visible                                        |Sla op                                                       |
+|$datum2=                                                |store                             |!today (dd-MM-yyyy HH:mm) |
+|Npo poms Tabblad object Detailscherm Vul                |$datum2                           |in tekstveld|Start        |
+|click                                                   |Sla op                                                       |
+|wait for not visible                                    |Sla op                                                       |
+|Npo poms Tabblad object Druk op link                    |Algemeen                          |in sidebar                |
+|wait for visible                                        |Sorteerdatum                                                 |
+|Npo poms Tabblad object Check veldtype 2                |Sorteerdatum                      |heeft waarde|$datum2      |
+|Npo poms Tabblad object Druk op link                    |Platformen                        |in sidebar                |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                   |
+|Npo poms Zoeken Dubbelklik op platform                  |${platform}                                                  |
+|wait for visible                                        |Sla op                                                       |
+|Npo poms Tabblad object Detailscherm Vul                |$datum1                           |in tekstveld|Start        |
+|click                                                   |Sla op                                                       |
+|wait for not visible                                    |Sla op                                                       |
+|Npo poms Tabblad object Druk op link                    |Algemeen                          |in sidebar                |
+|wait for visible                                        |Sorteerdatum                                                 |
+|Npo poms Tabblad object Check veldtype 2                |Sorteerdatum                      |heeft waarde|$datum1      |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                |
+|Npo poms Hoofdscherm Log uit                                                                                          |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa27-SpomsEditUpload1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa27-SpomsEditUpload1.wiki
@@ -10,62 +10,57 @@ Test
 
 *!
 
-|script                                                                                                                                       |
-|Open Npo poms website                                                                                                                        |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                          |
-|Npo poms Zoeken Selecteer optie                             |${mediatype}   |in dropdown                        |!-MediaType-!               |
-|Npo poms Zoeken Selecteer optie                             |${omroep}      |in dropdown                        |Omroepen                    |
-|wait for visible                                            |Gezocht naar: ${mediatype}, ${omroep}                                           |
-|Npo poms Zoeken Sla hoofdtitel van object nummer            |${objectNummer}|op in var                          |titelVanObject              |
-|Npo poms Zoeken Sla type van object nummer                  |${objectNummer}|op in var                          |typeVanObject               |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer  |${objectNummer}                                                                 |
-|Npo poms Hoofdscherm Wacht tot tabblad                      |$titelVanObject|geopend                                                         |
-|Npo poms Hoofdscherm Check titel van laatste tab            |$titelVanObject                                                                 |
-|Npo poms Hoofdscherm Check subtitel van laatste tab         |$typeVanObject                                                                  |
-|Npo poms Tabblad object Sla mid of urn op in var            |mid                                                                             |
-|Npo poms Tabblad object Druk op link                        |Afbeeldingen   |in sidebar                                                      |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                          |
-|set search context to                                       |xpath=//poms-images                                                             |
-|Npo poms Tabblad object Sla aantal in veld                  |Afbeeldingen   |op in var                          |aantalAfbeeldingen          |
-|click                                                       |Afbeelding toevoegen                                                            |
-|clear search context                                                                                                                         |
-|select file                                                 |${plaatje}     |for                                |css=input[id=inputFile]     |
-|wait for visible                                            |css=img                                                                         |
-|show                                                        |take screenshot|${screenshot}_!today (yyyyMMddHHmmss)                           |
-|Npo poms Tabblad object Detailscherm Check knop             |Maak aan       |in footer inactief                                              |
-|Npo poms Tabblad object Detailscherm Vul                    |${titel}       |in tekstveld                       |Titel *                     |
-|Npo poms Tabblad object Detailscherm Check knop             |Maak aan       |in footer inactief                                              |
-|Npo poms Tabblad object Detailscherm Vul                    |${beschrijving}|in textarea                        |Beschrijving *              |
-|Npo poms Tabblad object Detailscherm Check knop             |Maak aan       |in footer inactief                                              |
-|scroll to                                                   |Afbeeldingstype *                                                               |
-|Npo poms Tabblad object Detailscherm Selecteer optie        |Afbeelding     |in selecteerbare tekstveld         |Afbeeldingstype *           |
-|Npo poms Tabblad object Detailscherm Check knop             |Maak aan       |in footer actief                                                |
-|click                                                       |Maak aan                                                                        |
-|check                                                       |value of       |xpath=//div[@class="modal-message"]|${waarschuwingFotosUploaden}|
-|click                                                       |begrepen                                                                        |
-|wait for not visible                                        |begrepen                                                                        |
-|Npo poms Tabblad object Check afbeelding                    |${titel}       |zichtbaar                                                       |
-|Npo poms Tabblad object Check afbeelding                    |${titel}       |heeft beschrijving                 |${beschrijving}             |
-|Npo poms Tabblad object Wacht tot preview afbeelding van    |${titel}       |zichtbaar                                                       |
-|set search context to                                       |xpath=//poms-images                                                             |
-|Npo poms Tabblad object Check aantal in veld                |Afbeeldingen   |is var                             |aantalAfbeeldingen |plus |1 |
-|clear search context                                                                                                                         |
-|show                                                        |take screenshot|${screenshot}_!today (yyyyMMddHHmmss)                           |
-|Npo poms Tabblad object Druk op preview afbeelding van      |${titel}                                                                        |
-|switch to next tab                                                                                                                           |
-|wait for visible                                            |css=img                                                                         |
-|show                                                        |take screenshot|${screenshot}_!today (yyyyMMddHHmmss)                           |
-|close tab                                                                                                                                    |
-|Npo poms Tabblad object Hover over afbeelding               |${titel}                                                                        |
-|Npo poms Tabblad object Druk op verwijderknop bij afbeelding|${titel}                                                                        |
-|wait for visible                                            |Afbeelding verwijderen?                                                         |
-|click                                                       |xpath=//button[text()="verwijderen"]                                            |
-|wait for not visible                                        |Afbeelding verwijderen?                                                         |
-|set search context to                                       |xpath=//poms-images                                                             |
-|Npo poms Tabblad object Check aantal in veld                |Afbeeldingen   |is var                             |aantalAfbeeldingen          |
-|Npo poms Tabblad object Check afbeelding                    |${titel}       |niet zichtbaar                                                  |
-|clear search context                                                                                                                         |
-|show                                                        |take screenshot|${screenshot}_!today (yyyyMMddHHmmss)                           |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                       |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                       |
-|Npo poms Hoofdscherm Log uit                                                                                                                 |
+|script                                                                                                                                               |
+|Open Npo poms website                                                                                                                                |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                  |
+|Npo poms Zoeken Selecteer optie                             |${mediatype}           |in dropdown                        |!-MediaType-!               |
+|Npo poms Zoeken Selecteer optie                             |${omroep}              |in dropdown                        |Omroepen                    |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:    |${mediatype}, ${omroep}|klaar is                                                        |
+|Npo poms Zoeken Open object nummer                          |${objectNummer}                                                                         |
+|Npo poms Tabblad object Sla mid of urn op in var            |mid                                                                                     |
+|Npo poms Tabblad object Druk op link                        |Afbeeldingen           |in sidebar                                                      |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                  |
+|set search context to                                       |xpath=//poms-images                                                                     |
+|Npo poms Tabblad object Sla aantal in veld                  |Afbeeldingen           |op in var                          |aantalAfbeeldingen          |
+|click                                                       |Afbeelding toevoegen                                                                    |
+|clear search context                                                                                                                                 |
+|select file                                                 |${plaatje}             |for                                |css=input[id=inputFile]     |
+|wait for visible                                            |css=img                                                                                 |
+|show                                                        |take screenshot        |${screenshot}_!today (yyyyMMddHHmmss)                           |
+|Npo poms Tabblad object Detailscherm Check knop             |Maak aan               |in footer inactief                                              |
+|Npo poms Tabblad object Detailscherm Vul                    |${titel}               |in tekstveld                       |Titel *                     |
+|Npo poms Tabblad object Detailscherm Check knop             |Maak aan               |in footer inactief                                              |
+|Npo poms Tabblad object Detailscherm Vul                    |${beschrijving}        |in textarea                        |Beschrijving *              |
+|Npo poms Tabblad object Detailscherm Check knop             |Maak aan               |in footer inactief                                              |
+|scroll to                                                   |Afbeeldingstype *                                                                       |
+|Npo poms Tabblad object Detailscherm Selecteer optie        |Afbeelding             |in selecteerbare tekstveld         |Afbeeldingstype *           |
+|Npo poms Tabblad object Detailscherm Check knop             |Maak aan               |in footer actief                                                |
+|click                                                       |Maak aan                                                                                |
+|check                                                       |value of               |xpath=//div[@class="modal-message"]|${waarschuwingFotosUploaden}|
+|click                                                       |begrepen                                                                                |
+|wait for not visible                                        |begrepen                                                                                |
+|Npo poms Tabblad object Check afbeelding                    |${titel}               |zichtbaar                                                       |
+|Npo poms Tabblad object Check afbeelding                    |${titel}               |heeft beschrijving                 |${beschrijving}             |
+|Npo poms Tabblad object Wacht tot preview afbeelding van    |${titel}               |zichtbaar                                                       |
+|set search context to                                       |xpath=//poms-images                                                                     |
+|Npo poms Tabblad object Check aantal in veld                |Afbeeldingen           |is var                             |aantalAfbeeldingen |plus |1 |
+|clear search context                                                                                                                                 |
+|show                                                        |take screenshot        |${screenshot}_!today (yyyyMMddHHmmss)                           |
+|Npo poms Tabblad object Druk op preview afbeelding van      |${titel}                                                                                |
+|switch to next tab                                                                                                                                   |
+|wait for visible                                            |css=img                                                                                 |
+|show                                                        |take screenshot        |${screenshot}_!today (yyyyMMddHHmmss)                           |
+|close tab                                                                                                                                            |
+|Npo poms Tabblad object Hover over afbeelding               |${titel}                                                                                |
+|Npo poms Tabblad object Druk op verwijderknop bij afbeelding|${titel}                                                                                |
+|wait for visible                                            |Afbeelding verwijderen?                                                                 |
+|click                                                       |xpath=//button[text()="verwijderen"]                                                    |
+|wait for not visible                                        |Afbeelding verwijderen?                                                                 |
+|set search context to                                       |xpath=//poms-images                                                                     |
+|Npo poms Tabblad object Check aantal in veld                |Afbeeldingen           |is var                             |aantalAfbeeldingen          |
+|Npo poms Tabblad object Check afbeelding                    |${titel}               |niet zichtbaar                                                  |
+|clear search context                                                                                                                                 |
+|show                                                        |take screenshot        |${screenshot}_!today (yyyyMMddHHmmss)                           |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                               |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                               |
+|Npo poms Hoofdscherm Log uit                                                                                                                         |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa28-SpomsEditUpload2.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa28-SpomsEditUpload2.wiki
@@ -10,50 +10,42 @@ Test
 
 *!
 
-|script                                                                                                                                     |
-|Open Npo poms website                                                                                                                      |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                        |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}   |in dropdown                        |!-MediaType-!               |
-|Npo poms Zoeken Selecteer optie                           |${omroep}      |in dropdown                        |Omroepen                    |
-|wait for visible                                          |Gezocht naar: ${mediatype}, ${omroep}                                           |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |${objectNummer}|op in var                          |titelVanObject              |
-|Npo poms Zoeken Sla type van object nummer                |${objectNummer}|op in var                          |typeVanObject               |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer|${objectNummer}                                                                 |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject|geopend                                                         |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                                 |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                                  |
-|Npo poms Tabblad object Sla mid of urn op in var          |mid                                                                             |
-|Npo poms Tabblad object Druk op link                      |Afbeeldingen   |in sidebar                                                      |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                        |
-|set search context to                                     |xpath=//poms-images                                                             |
-|Npo poms Tabblad object Sla aantal in veld                |Afbeeldingen   |op in var                          |aantalAfbeeldingen          |
-|click                                                     |Afbeelding toevoegen                                                            |
-|clear search context                                                                                                                       |
-|select file                                               |${plaatje}     |for                                |css=input[id=inputFile]     |
-|wait for visible                                          |css=img                                                                         |
-|show                                                      |take screenshot|${screenshot}_!today (yyyyMMddHHmmss)                           |
-|Npo poms Tabblad object Detailscherm Vul                  |${titel}       |in tekstveld                       |Titel *                     |
-|Npo poms Tabblad object Detailscherm Vul                  |${beschrijving}|in textarea                        |Beschrijving *              |
-|scroll to                                                 |Afbeeldingstype *                                                               |
-|Npo poms Tabblad object Detailscherm Selecteer optie      |Afbeelding     |in selecteerbare tekstveld         |Afbeeldingstype *           |
-|click                                                     |Maak aan                                                                        |
-|check                                                     |value of       |xpath=//div[@class="modal-message"]|${waarschuwingFotosUploaden}|
-|click                                                     |begrepen                                                                        |
-|wait for not visible                                      |begrepen                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                     |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                     |
-|Npo poms Hoofdscherm Log uit                                                                                                               |
+|script                                                                                                                                           |
+|Open Npo poms website                                                                                                                            |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                              |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}           |in dropdown                        |!-MediaType-!               |
+|Npo poms Zoeken Selecteer optie                         |${omroep}              |in dropdown                        |Omroepen                    |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep}|klaar is                                                        |
+|Npo poms Zoeken Open object nummer                      |${objectNummer}                                                                         |
+|Npo poms Tabblad object Sla mid of urn op in var        |mid                                                                                     |
+|Npo poms Tabblad object Druk op link                    |Afbeeldingen           |in sidebar                                                      |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                              |
+|set search context to                                   |xpath=//poms-images                                                                     |
+|Npo poms Tabblad object Sla aantal in veld              |Afbeeldingen           |op in var                          |aantalAfbeeldingen          |
+|click                                                   |Afbeelding toevoegen                                                                    |
+|clear search context                                                                                                                             |
+|select file                                             |${plaatje}             |for                                |css=input[id=inputFile]     |
+|wait for visible                                        |css=img                                                                                 |
+|show                                                    |take screenshot        |${screenshot}_!today (yyyyMMddHHmmss)                           |
+|Npo poms Tabblad object Detailscherm Vul                |${titel}               |in tekstveld                       |Titel *                     |
+|Npo poms Tabblad object Detailscherm Vul                |${beschrijving}        |in textarea                        |Beschrijving *              |
+|scroll to                                               |Afbeeldingstype *                                                                       |
+|Npo poms Tabblad object Detailscherm Selecteer optie    |Afbeelding             |in selecteerbare tekstveld         |Afbeeldingstype *           |
+|click                                                   |Maak aan                                                                                |
+|check                                                   |value of               |xpath=//div[@class="modal-message"]|${waarschuwingFotosUploaden}|
+|click                                                   |begrepen                                                                                |
+|wait for not visible                                    |begrepen                                                                                |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                           |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                           |
+|Npo poms Hoofdscherm Log uit                                                                                                                     |
 
 
 |script                                                                                                                   |
 |Npo poms Inlogscherm Log in met admin                                                                                    |
 |Npo poms Zoeken Vul                                         |$mid           |in zoekveld                                 |
 |Npo poms Zoeken Druk knop                                   |Zoeken                                                      |
-|wait for visible                                            |Gezocht naar: '$mid'                                        |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                               |
-|Npo poms Hoofdscherm Wacht tot tabblad                      |$titelVanObject|geopend                                     |
-|Npo poms Hoofdscherm Check titel van laatste tab            |$titelVanObject                                             |
-|Npo poms Hoofdscherm Check subtitel van laatste tab         |$typeVanObject                                              |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:    |'$mid'         |klaar is                                    |
+|Npo poms Zoeken Open eerste object                                                                                       |
 |Npo poms Tabblad object Druk op link                        |Afbeeldingen   |in sidebar                                  |
 |wait for visible                                            |Afbeelding toevoegen                                        |
 |Npo poms Tabblad object Check afbeelding                    |${titel}       |zichtbaar                                   |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa29-SpomsEditAuthorisatie1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa29-SpomsEditAuthorisatie1.wiki
@@ -13,23 +13,18 @@ Test
 
 *!
 
-|script                                                                                              |
-|Open Npo poms website                                                                               |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                 |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}   |in dropdown|!-MediaType-!|
-|Npo poms Zoeken Selecteer optie                           |${omroep}      |in dropdown|Omroepen     |
-|wait for visible                                          |Gezocht naar: ${mediatype}, ${omroep}    |
-|Npo poms Zoeken Druk op tandwieltje                                                                 |
-|set search context to                                     |xpath=//poms-search-columns              |
-|click                                                     |${kolomOmroep}                           |
-|clear search context                                                                                |
-|Npo poms Zoeken Check eerste object heeft geen omroep     |${omroepNietAanwezig}                    |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                           |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                            |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                          |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject|geopend                  |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                          |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                           |
+|script                                                                                                    |
+|Open Npo poms website                                                                                     |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                       |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}           |in dropdown|!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${omroep}              |in dropdown|Omroepen     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep}|klaar is                 |
+|Npo poms Zoeken Druk op tandwieltje                                                                       |
+|set search context to                                   |xpath=//poms-search-columns                      |
+|click                                                   |${kolomOmroep}                                   |
+|clear search context                                                                                      |
+|Npo poms Zoeken Check eerste object heeft geen omroep   |${omroepNietAanwezig}                            |
+|Npo poms Zoeken Open eerste object                                                                        |
 
 |Npo poms Tabblad object Check veld niet te bewerken en niet te verwijderen|
 |veld                       |heeft slotje? |kan bewerken? |kan verwijderen?|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa30-SpomsEditAuthorisatie2.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa30-SpomsEditAuthorisatie2.wiki
@@ -10,13 +10,13 @@ Test
 
 *!
 
-|script                                                                                        |
-|Open Npo poms website                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                           |
-|Npo poms Zoeken Selecteer optie            |${mediatype}    |in dropdown    |!-MediaType-!    |
-|Npo poms Zoeken Selecteer optie            |${omroep}       |in dropdown    |Omroepen         |
-|Npo poms Zoeken Selecteer optie            |${criteria}     |in dropdown    |Criteria         |
-|wait for visible                           |Gezocht naar: ${mediatype}, ${omroep}, ${criteria}|
-|Npo poms Zoeken Check aantal zoekresultaten|0                                                 |
-|Npo poms Hoofdscherm Sluit laatste tab                                                        |
-|Npo poms Hoofdscherm Log uit                                                                  |
+|script                                                                                                                 |
+|Open Npo poms website                                                                                                  |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                    |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}                        |in dropdown|!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${omroep}                           |in dropdown|Omroepen     |
+|Npo poms Zoeken Selecteer optie                         |${criteria}                         |in dropdown|Criteria     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep}, ${criteria}|klaar is                 |
+|Npo poms Zoeken Check aantal zoekresultaten             |0                                                             |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                 |
+|Npo poms Hoofdscherm Log uit                                                                                           |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa31-SpomsEditAuthorisatie3.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa31-SpomsEditAuthorisatie3.wiki
@@ -11,18 +11,13 @@ Test
 
 *!
 
-|script                                                                                              |
-|Open Npo poms website                                                                               |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                 |
-|Npo poms Zoeken Selecteer optie                           |${mediatype}   |in dropdown|!-MediaType-!|
-|Npo poms Zoeken Selecteer optie                           |${omroep}      |in dropdown|Omroepen     |
-|wait for visible                                          |Gezocht naar: ${mediatype}, ${omroep}    |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                           |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                            |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                          |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject|geopend                  |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                          |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                           |
+|script                                                                                                    |
+|Open Npo poms website                                                                                     |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                       |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}           |in dropdown|!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${omroep}              |in dropdown|Omroepen     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep}|klaar is                 |
+|Npo poms Zoeken Open eerste object                                                                        |
 
 |Npo poms Tabblad object Check veld niet te bewerken en niet te verwijderen|
 |veld                       |heeft slotje? |kan bewerken? |kan verwijderen?|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa32-SpomsEditAuthorisatie4.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa32-SpomsEditAuthorisatie4.wiki
@@ -10,26 +10,26 @@ Test
 
 *!
 
-|script                                                                                 |
-|Open Npo poms website                                                                  |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                    |
-|Npo poms Zoeken Selecteer optie                 |${mediatype}|in dropdown|!-MediaType-!|
-|Npo poms Zoeken Selecteer optie                 |${omroep1}  |in dropdown|Omroepen     |
-|wait for visible                                |Gezocht naar: ${mediatype}, ${omroep1}|
-|click                                           |Onderdeel van                         |
-|click                                           |zoek een item                         |
-|wait for visible                                |Gezocht naar: Groep, niet:            |
-|set search context to                           |xpath=//div[@class="modal-body"]      |
-|Npo poms Zoeken Selecteer optie                 |${omroep2}  |in dropdown|Omroepen     |
-|clear search context                                                                   |
-|wait for visible                                |Gezocht naar: Groep, ${omroep2}, niet:|
-|Npo poms Zoeken Druk op tandwieltje                                                    |
-|set search context to                           |xpath=//poms-search-columns           |
-|click                                           |xpath=//span[text()="Omroep"]         |
-|clear search context                                                                   |
-|Npo poms Zoeken Druk op tandwieltje                                                    |
-|Npo poms Zoeken Check eerste object heeft omroep|${omroep1}                            |
-|Npo poms Zoeken Check eerste object heeft omroep|${omroep2}                            |
-|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten              |
-|Npo poms Hoofdscherm Sluit laatste tab                                                 |
-|Npo poms Hoofdscherm Log uit                                                           |
+|script                                                                                                     |
+|Open Npo poms website                                                                                      |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                        |
+|Npo poms Zoeken Selecteer optie                         |${mediatype}            |in dropdown|!-MediaType-!|
+|Npo poms Zoeken Selecteer optie                         |${omroep1}              |in dropdown|Omroepen     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype}, ${omroep1}|klaar is                 |
+|click                                                   |Onderdeel van                                     |
+|click                                                   |zoek een item                                     |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Groep, niet:            |klaar is                 |
+|set search context to                                   |xpath=//div[@class="modal-body"]                  |
+|Npo poms Zoeken Selecteer optie                         |${omroep2}              |in dropdown|Omroepen     |
+|clear search context                                                                                       |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Groep, ${omroep2}, niet:|klaar is                 |
+|Npo poms Zoeken Druk op tandwieltje                                                                        |
+|set search context to                                   |xpath=//poms-search-columns                       |
+|click                                                   |xpath=//span[text()="Omroep"]                     |
+|clear search context                                                                                       |
+|Npo poms Zoeken Druk op tandwieltje                                                                        |
+|Npo poms Zoeken Check eerste object heeft omroep        |${omroep1}                                        |
+|Npo poms Zoeken Check eerste object heeft omroep        |${omroep2}                                        |
+|Npo poms Tabblad object Detailscherm Druk op kruisje om pop-up te sluiten                                  |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                     |
+|Npo poms Hoofdscherm Log uit                                                                               |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa33-SpomsEditAuthorisatie5.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa33-SpomsEditAuthorisatie5.wiki
@@ -12,48 +12,43 @@ Test
 
 *!
 
-|script                                                                                                           |
-|Open Npo poms website                                                                                            |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                              |
-|Npo poms Zoeken Selecteer optie                           |${mediatype1}     |in dropdown|!-MediaType-!          |
-|Npo poms Zoeken Selecteer optie                           |${omroep1}        |in dropdown|Omroepen               |
-|wait for visible                                          |Gezocht naar: ${mediatype1}, ${omroep1}               |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                                        |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                                         |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                       |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject   |geopend                            |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                       |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                        |
-|Npo poms Tabblad object Sla mid of urn op in var          |mid                                                   |
-|Npo poms Tabblad object Druk op link                      |Onderdelen        |in sidebar                         |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                              |
-|Npo poms Tabblad object Sla aantal in veld                |Onderdelen        |op in var  |aantalOnderdelen       |
-|set search context to                                     |xpath=//poms-members                                  |
-|click                                                     |Onderdeel toevoegen                                   |
-|clear search context                                                                                             |
-|Npo poms Zoeken Selecteer optie                           |${mediatype2}     |in dropdown|!-MediaType-!          |
-|Npo poms Zoeken Selecteer optie                           |${omroep2}        |in dropdown|Omroepen               |
-|wait for visible                                          |Gezocht naar: ${mediatype2}, ${omroep2}, niet: $mid   |
-|Npo poms Zoeken Sla hoofdtitel van object nummer          |${objectNummer}   |op in var  |titelVanOnderdeel      |
-|Npo poms Zoeken Sla type van object nummer                |${objectNummer}   |op in var  |typeVanOnderdeel       |
-|Npo poms Zoeken Vink checkbox aan bij object nummer       |${objectNummer}   |in zoekresultaten                  |
-|click                                                     |Kies                                                  |
-|wait for not visible                                      |Kies                                                  |
-|set search context to                                     |xpath=//poms-members                                  |
-|Npo poms Tabblad object Check item                        |$titelVanOnderdeel|zichtbaar                          |
-|Npo poms Tabblad object Check onderdeel                   |$titelVanOnderdeel|heeft type |$typeVanOnderdeel      |
-|Npo poms Tabblad object Check aantal in veld              |Onderdelen        |is var     |aantalOnderdelen|plus|1|
-|Npo poms Tabblad object Hover over item                   |$titelVanOnderdeel                                    |
-|Npo poms Tabblad object Druk op verwijderknop bij item    |$titelVanOnderdeel                                    |
-|clear search context                                                                                             |
-|wait for visible                                          |verwijderen?                                          |
-|click                                                     |xpath=//button[text()="verwijderen"]                  |
-|wait for not visible                                      |verwijderen?                                          |
-|Wacht tot Angular requests klaar zijn                                                                            |
-|Npo poms Tabblad object Check aantal in veld              |Onderdelen        |is var     |aantalOnderdelen       |
-|set search context to                                     |xpath=//poms-members                                  |
-|Npo poms Tabblad object Check item                        |$titelVanOnderdeel|niet zichtbaar                     |
-|clear search context                                                                                             |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                           |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                           |
-|Npo poms Hoofdscherm Log uit                                                                                     |
+|script                                                                                                                            |
+|Open Npo poms website                                                                                                             |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                               |
+|Npo poms Zoeken Selecteer optie                         |${mediatype1}                        |in dropdown|!-MediaType-!          |
+|Npo poms Zoeken Selecteer optie                         |${omroep1}                           |in dropdown|Omroepen               |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype1}, ${omroep1}            |klaar is                           |
+|Npo poms Zoeken Open eerste object                                                                                                |
+|Npo poms Tabblad object Sla mid of urn op in var        |mid                                                                      |
+|Npo poms Tabblad object Druk op link                    |Onderdelen                           |in sidebar                         |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                               |
+|Npo poms Tabblad object Sla aantal in veld              |Onderdelen                           |op in var  |aantalOnderdelen       |
+|set search context to                                   |xpath=//poms-members                                                     |
+|click                                                   |Onderdeel toevoegen                                                      |
+|clear search context                                                                                                              |
+|Npo poms Zoeken Selecteer optie                         |${mediatype2}                        |in dropdown|!-MediaType-!          |
+|Npo poms Zoeken Selecteer optie                         |${omroep2}                           |in dropdown|Omroepen               |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype2}, ${omroep2}, niet: $mid|klaar is                           |
+|Npo poms Zoeken Sla hoofdtitel van object nummer        |${objectNummer}                      |op in var  |titelVanOnderdeel      |
+|Npo poms Zoeken Sla type van object nummer              |${objectNummer}                      |op in var  |typeVanOnderdeel       |
+|Npo poms Zoeken Vink checkbox aan bij object nummer     |${objectNummer}                      |in zoekresultaten                  |
+|click                                                   |Kies                                                                     |
+|wait for not visible                                    |Kies                                                                     |
+|set search context to                                   |xpath=//poms-members                                                     |
+|Npo poms Tabblad object Check item                      |$titelVanOnderdeel                   |zichtbaar                          |
+|Npo poms Tabblad object Check onderdeel                 |$titelVanOnderdeel                   |heeft type |$typeVanOnderdeel      |
+|Npo poms Tabblad object Check aantal in veld            |Onderdelen                           |is var     |aantalOnderdelen|plus|1|
+|Npo poms Tabblad object Hover over item                 |$titelVanOnderdeel                                                       |
+|Npo poms Tabblad object Druk op verwijderknop bij item  |$titelVanOnderdeel                                                       |
+|clear search context                                                                                                              |
+|wait for visible                                        |verwijderen?                                                             |
+|click                                                   |xpath=//button[text()="verwijderen"]                                     |
+|wait for not visible                                    |verwijderen?                                                             |
+|Wacht tot Angular requests klaar zijn                                                                                             |
+|Npo poms Tabblad object Check aantal in veld            |Onderdelen                           |is var     |aantalOnderdelen       |
+|set search context to                                   |xpath=//poms-members                                                     |
+|Npo poms Tabblad object Check item                      |$titelVanOnderdeel                   |niet zichtbaar                     |
+|clear search context                                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                            |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                            |
+|Npo poms Hoofdscherm Log uit                                                                                                      |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa34-SpomsEditAuthorisatie6.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa34-SpomsEditAuthorisatie6.wiki
@@ -13,39 +13,39 @@ Test
 
 *!
 
-|script                                                                                                       |
-|Open Npo poms website                                                                                        |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                          |
-|Npo poms Tabblad object Open                          |${mid}                                                |
-|Npo poms Tabblad object Druk op link                  |Onderdelen        |in sidebar                         |
-|Npo poms Tabblad object Wacht tot scrollen klaar is                                                          |
-|Npo poms Tabblad object Sla aantal in veld            |Onderdelen        |op in var  |aantalOnderdelen       |
-|set search context to                                 |xpath=//poms-members                                  |
-|click                                                 |Onderdeel toevoegen                                   |
-|clear search context                                                                                         |
-|Npo poms Zoeken Selecteer optie                       |${mediatype2}     |in dropdown|!-MediaType-!          |
-|Npo poms Zoeken Selecteer optie                       |${omroep2}        |in dropdown|Omroepen               |
-|wait for visible                                      |Gezocht naar: ${mediatype2}, ${omroep2}, niet: ${mid} |
-|Npo poms Zoeken Sla hoofdtitel van object nummer      |${objectNummer}   |op in var  |titelVanOnderdeel      |
-|Npo poms Zoeken Sla type van object nummer            |${objectNummer}   |op in var  |typeVanOnderdeel       |
-|Npo poms Zoeken Vink checkbox aan bij object nummer   |${objectNummer}   |in zoekresultaten                  |
-|click                                                 |Kies                                                  |
-|wait for not visible                                  |Kies                                                  |
-|set search context to                                 |xpath=//poms-members                                  |
-|Npo poms Tabblad object Check item                    |$titelVanOnderdeel|zichtbaar                          |
-|Npo poms Tabblad object Check onderdeel               |$titelVanOnderdeel|heeft type |$typeVanOnderdeel      |
-|Npo poms Tabblad object Check aantal in veld          |Onderdelen        |is var     |aantalOnderdelen|plus|1|
-|Npo poms Tabblad object Hover over item               |$titelVanOnderdeel                                    |
-|Npo poms Tabblad object Druk op verwijderknop bij item|$titelVanOnderdeel                                    |
-|clear search context                                                                                         |
-|wait for visible                                      |verwijderen?                                          |
-|click                                                 |xpath=//button[text()="verwijderen"]                  |
-|wait for not visible                                  |verwijderen?                                          |
-|Wacht tot Angular requests klaar zijn                                                                        |
-|Npo poms Tabblad object Check aantal in veld          |Onderdelen        |is var     |aantalOnderdelen       |
-|set search context to                                 |xpath=//poms-members                                  |
-|Npo poms Tabblad object Check item                    |$titelVanOnderdeel|niet zichtbaar                     |
-|clear search context                                                                                         |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                       |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                       |
-|Npo poms Hoofdscherm Log uit                                                                                 |
+|script                                                                                                                              |
+|Open Npo poms website                                                                                                               |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                 |
+|Npo poms Tabblad object Open                            |${mid}                                                                     |
+|Npo poms Tabblad object Druk op link                    |Onderdelen                             |in sidebar                         |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                 |
+|Npo poms Tabblad object Sla aantal in veld              |Onderdelen                             |op in var  |aantalOnderdelen       |
+|set search context to                                   |xpath=//poms-members                                                       |
+|click                                                   |Onderdeel toevoegen                                                        |
+|clear search context                                                                                                                |
+|Npo poms Zoeken Selecteer optie                         |${mediatype2}                          |in dropdown|!-MediaType-!          |
+|Npo poms Zoeken Selecteer optie                         |${omroep2}                             |in dropdown|Omroepen               |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${mediatype2}, ${omroep2}, niet: ${mid}|klaar is                           |
+|Npo poms Zoeken Sla hoofdtitel van object nummer        |${objectNummer}                        |op in var  |titelVanOnderdeel      |
+|Npo poms Zoeken Sla type van object nummer              |${objectNummer}                        |op in var  |typeVanOnderdeel       |
+|Npo poms Zoeken Vink checkbox aan bij object nummer     |${objectNummer}                        |in zoekresultaten                  |
+|click                                                   |Kies                                                                       |
+|wait for not visible                                    |Kies                                                                       |
+|set search context to                                   |xpath=//poms-members                                                       |
+|Npo poms Tabblad object Check item                      |$titelVanOnderdeel                     |zichtbaar                          |
+|Npo poms Tabblad object Check onderdeel                 |$titelVanOnderdeel                     |heeft type |$typeVanOnderdeel      |
+|Npo poms Tabblad object Check aantal in veld            |Onderdelen                             |is var     |aantalOnderdelen|plus|1|
+|Npo poms Tabblad object Hover over item                 |$titelVanOnderdeel                                                         |
+|Npo poms Tabblad object Druk op verwijderknop bij item  |$titelVanOnderdeel                                                         |
+|clear search context                                                                                                                |
+|wait for visible                                        |verwijderen?                                                               |
+|click                                                   |xpath=//button[text()="verwijderen"]                                       |
+|wait for not visible                                    |verwijderen?                                                               |
+|Wacht tot Angular requests klaar zijn                                                                                               |
+|Npo poms Tabblad object Check aantal in veld            |Onderdelen                             |is var     |aantalOnderdelen       |
+|set search context to                                   |xpath=//poms-members                                                       |
+|Npo poms Tabblad object Check item                      |$titelVanOnderdeel                     |niet zichtbaar                     |
+|clear search context                                                                                                                |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                              |
+|Npo poms Hoofdscherm Log uit                                                                                                        |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa37-SpomsEditLexico1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa37-SpomsEditLexico1.wiki
@@ -1,5 +1,5 @@
 ---
-Suites: MT
+Suites: JF
 Test
 ---
 !include -c <Wijzigen.Variabelen
@@ -10,25 +10,21 @@ Test
 
 *!
 
-|script                                                                                                                           |
-|Open Npo poms website                                                                                                            |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                              |
-|Npo poms Zoeken Selecteer optie                                                |Trailer              |in dropdown |!-MediaType-! |
-|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:                       |Trailer              |klaar is                   |
-|Npo poms Zoeken Sla hoofdtitel van object nummer                               |${objectNummer}      |op in var   |titelVanObject|
-|Npo poms Zoeken Sla type van object nummer                                     |${objectNummer}      |op in var   |typeVanObject |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van object nummer                     |${objectNummer}                                  |
-|Npo poms Hoofdscherm Wacht tot tabblad                                         |$titelVanObject      |geopend                    |
-|Npo poms Hoofdscherm Check titel van laatste tab                               |$titelVanObject                                  |
-|Npo poms Hoofdscherm Check subtitel van laatste tab                            |$typeVanObject                                   |
-|Npo poms Tabblad object Verander hoofdtitel naar                               |TEST                                             |
-|Npo poms Tabblad object Start met bewerken Lexicografische titel                                                                 |
-|Npo poms Tabblad object Check tekst in invoerveld Lexicografische titel is     |TEST                                             |
-|Npo poms Tabblad object Verander tekst in invoerveld Lexicografische titel naar|TESTCASE             |en sla op                  |
-|Npo poms Tabblad object Wacht tot veldtype 2                                   |Lexicografische titel|heeft waarde|TESTCASE      |
-|Npo poms Tabblad object Start met bewerken Lexicografische titel                                                                 |
-|Npo poms Tabblad object Verander tekst in invoerveld Lexicografische titel naar|                     |en sla op                  |
-|Npo poms Tabblad object Verander hoofdtitel naar                               |$titelVanObject                                  |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                           |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                           |
-|Npo poms Hoofdscherm Log uit                                                                                                     |
+|script                                                                                                                          |
+|Open Npo poms website                                                                                                           |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                             |
+|Npo poms Zoeken Selecteer optie                                                |Trailer              |in dropdown |!-MediaType-!|
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:                       |Trailer              |klaar is                  |
+|Npo poms Zoeken Open object nummer                                             |${objectNummer}                                 |
+|Npo poms Tabblad object Sla hoofdtitel op in var                               |titelVanObject                                  |
+|Npo poms Tabblad object Verander hoofdtitel naar                               |TEST                                            |
+|Npo poms Tabblad object Start met bewerken Lexicografische titel                                                                |
+|Npo poms Tabblad object Check tekst in invoerveld Lexicografische titel is     |TEST                                            |
+|Npo poms Tabblad object Verander tekst in invoerveld Lexicografische titel naar|TESTCASE             |en sla op                 |
+|Npo poms Tabblad object Wacht tot veldtype 2                                   |Lexicografische titel|heeft waarde|TESTCASE     |
+|Npo poms Tabblad object Start met bewerken Lexicografische titel                                                                |
+|Npo poms Tabblad object Verander tekst in invoerveld Lexicografische titel naar|                     |en sla op                 |
+|Npo poms Tabblad object Verander hoofdtitel naar                               |$titelVanObject                                 |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Hoofdscherm Log uit                                                                                                    |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa38-SpomsEditLocaties1.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Wijzigen/NpoTa38-SpomsEditLocaties1.wiki
@@ -9,38 +9,33 @@ Test
 
 *!
 
-|script                                                                                                                                                        |
-|Open Npo poms website                                                                                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                           |
-|Npo poms Zoeken Selecteer optie                           |Clip                            |in dropdown                  |!-MediaType-!                       |
-|Npo poms Zoeken Selecteer optie                           |Mag schrijven                   |in dropdown                  |Criteria                            |
-|Npo poms Zoeken Selecteer optie                           |Zonder bron                     |in dropdown                  |Criteria                            |
-|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:  |Clip, Mag schrijven, Zonder bron|klaar is                                                          |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanObject                                                                                     |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanObject                                                                                      |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanObject                 |geopend                                                           |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanObject                                                                                    |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanObject                                                                                     |
-|Npo poms Tabblad object Druk op link                      |Bronnen                         |in sidebar                                                        |
-|wait for visible                                          |Bron toevoegen                                                                                     |
-|$aantalBronnen1=                                          |value of                        |xpath=//poms-locations/div/h1                                     |
-|$aantalBronnen1=                                          |extract string                  |$aantalBronnen1              |from|Bronnen \((\d+)\)|using group|1|
-|set search context to                                     |xpath=//poms-locations                                                                             |
-|click                                                     |Bron toevoegen                                                                                     |
-|clear search context                                                                                                                                          |
-|Npo poms Tabblad object Detailscherm Vul                  |${url}                          |in tekstveld                 |URL *                               |
-|Npo poms Tabblad object Detailscherm Selecteer optie      |${bronType}                     |in selecteerbare tekstveld   |Type *                              |
-|click                                                     |Maak aan                                                                                           |
-|Npo poms Tabblad object Check bron                        |${url}                          |zichtbaar                                                         |
-|Npo poms Tabblad object Check bron                        |${url}                          |heeft type                   |${bronType}                         |
-|$aantalBronnen2=                                          |add                             |$aantalBronnen1              |and |1                              |
-|check                                                     |value of                        |xpath=//poms-locations/div/h1|Bronnen ($aantalBronnen2)           |
-|Npo poms Tabblad object Hover over bron                   |${url}                                                                                             |
-|Npo poms Tabblad object Druk op verwijderknop bij bron    |${url}                                                                                             |
-|Npo poms Tabblad object Bevestig verwijdering van         |Bron                                                                                               |
-|wait for visible                                          |xpath=//poms-locations/div/h1[normalize-space(.)="Bronnen ($aantalBronnen1)"]                      |
-|Npo poms Tabblad object Check bron                        |${url}                          |niet zichtbaar                                                    |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                        |
-|Npo poms Hoofdscherm Log uit                                                                                                                                  |
+|script                                                                                                                                                      |
+|Open Npo poms website                                                                                                                                       |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                         |
+|Npo poms Zoeken Selecteer optie                         |Clip                            |in dropdown                  |!-MediaType-!                       |
+|Npo poms Zoeken Selecteer optie                         |Mag schrijven                   |in dropdown                  |Criteria                            |
+|Npo poms Zoeken Selecteer optie                         |Zonder bron                     |in dropdown                  |Criteria                            |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|Clip, Mag schrijven, Zonder bron|klaar is                                                          |
+|Npo poms Zoeken Open eerste object                                                                                                                          |
+|Npo poms Tabblad object Druk op link                    |Bronnen                         |in sidebar                                                        |
+|Npo poms Tabblad object Wacht tot scrollen klaar is                                                                                                         |
+|$aantalBronnen1=                                        |value of                        |xpath=//poms-locations/div/h1                                     |
+|$aantalBronnen1=                                        |extract string                  |$aantalBronnen1              |from|Bronnen \((\d+)\)|using group|1|
+|set search context to                                   |xpath=//poms-locations                                                                             |
+|click                                                   |Bron toevoegen                                                                                     |
+|clear search context                                                                                                                                        |
+|Npo poms Tabblad object Detailscherm Vul                |${url}                          |in tekstveld                 |URL *                               |
+|Npo poms Tabblad object Detailscherm Selecteer optie    |${bronType}                     |in selecteerbare tekstveld   |Type *                              |
+|click                                                   |Maak aan                                                                                           |
+|Npo poms Tabblad object Check bron                      |${url}                          |zichtbaar                                                         |
+|Npo poms Tabblad object Check bron                      |${url}                          |heeft type                   |${bronType}                         |
+|$aantalBronnen2=                                        |add                             |$aantalBronnen1              |and |1                              |
+|check                                                   |value of                        |xpath=//poms-locations/div/h1|Bronnen ($aantalBronnen2)           |
+|Npo poms Tabblad object Hover over bron                 |${url}                                                                                             |
+|Npo poms Tabblad object Druk op verwijderknop bij bron  |${url}                                                                                             |
+|Npo poms Tabblad object Bevestig verwijdering van       |Bron                                                                                               |
+|wait for visible                                        |xpath=//poms-locations/div/h1[normalize-space(.)="Bronnen ($aantalBronnen1)"]                      |
+|Npo poms Tabblad object Check bron                      |${url}                          |niet zichtbaar                                                    |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                      |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                      |
+|Npo poms Hoofdscherm Log uit                                                                                                                                |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa11-SpomsZoek2.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa11-SpomsZoek2.wiki
@@ -11,39 +11,29 @@ Test
 
 *!
 
-|script                                                                                                                                        |
-|Open Npo poms website                                                                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                           |
-|Npo poms Zoeken Vul                                       |${zoekopdracht}      |in zoekveld                                                  |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                             |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}'                                                    |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                              |
-|Npo poms Zoeken Selecteer optie                           |${mediatype1}        |in dropdown           |!-MediaType-!                         |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}' in ${mediatype1}                                   |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                              |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                               |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                      |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Zoeken Vul                                       |${zoekopdracht}      |in zoekveld                                                  |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                             |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}'                                                    |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                              |
-|Npo poms Zoeken Selecteer optie                           |${mediatype2}        |in dropdown           |!-MediaType-!                         |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}' in ${mediatype2}                                   |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                              |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                               |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                      |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Log uit                                                                                                                  |
+|script                                                                                                                                                   |
+|Open Npo poms website                                                                                                                                    |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                      |
+|Npo poms Zoeken Vul                                     |${zoekopdracht}                   |in zoekveld                                                  |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                          |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}'                 |klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                           |
+|Npo poms Zoeken Selecteer optie                         |${mediatype1}                     |in dropdown           |!-MediaType-!                         |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}' in ${mediatype1}|klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                           |
+|ensure                                                  |value                             |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
+|Npo poms Zoeken Open eerste object                                                                                                                       |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                   |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                   |
+|Npo poms Zoeken Vul                                     |${zoekopdracht}                   |in zoekveld                                                  |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                          |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}'                 |klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                           |
+|Npo poms Zoeken Selecteer optie                         |${mediatype2}                     |in dropdown           |!-MediaType-!                         |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}' in ${mediatype2}|klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                           |
+|ensure                                                  |value                             |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
+|Npo poms Zoeken Open eerste object                                                                                                                       |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                   |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                   |
+|Npo poms Hoofdscherm Log uit                                                                                                                             |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa12-SpomsZoek3.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa12-SpomsZoek3.wiki
@@ -10,23 +10,18 @@ Test
 
 *!
 
-|script                                                                                                                                        |
-|Open Npo poms website                                                                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                           |
-|Npo poms Zoeken Vul                                       |${zoekopdracht}      |in zoekveld                                                  |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                             |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}'                                                    |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                              |
-|Npo poms Zoeken Selecteer optie                           |${avtype}            |in dropdown           |!-avType-!                            |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}' in ${avtype}                                       |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                              |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                               |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                      |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Log uit                                                                                                                  |
+|script                                                                                                                                               |
+|Open Npo poms website                                                                                                                                |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                  |
+|Npo poms Zoeken Vul                                     |${zoekopdracht}               |in zoekveld                                                  |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                      |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}'             |klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                       |
+|Npo poms Zoeken Selecteer optie                         |${avtype}                     |in dropdown           |!-avType-!                            |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}' in ${avtype}|klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                       |
+|ensure                                                  |value                         |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
+|Npo poms Zoeken Open eerste object                                                                                                                   |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                               |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                               |
+|Npo poms Hoofdscherm Log uit                                                                                                                         |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa13-SpomsZoek4.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa13-SpomsZoek4.wiki
@@ -11,33 +11,23 @@ Test
 
 *!
 
-|script                                                                                                                                        |
-|Open Npo poms website                                                                                                                         |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                           |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                              |
-|Npo poms Zoeken Selecteer optie                           |${omroep}            |in dropdown           |Omroepen                              |
-|wait for visible                                          |Gezocht naar: ${omroep}                                                            |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                              |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                               |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                      |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                              |
-|Npo poms Zoeken Selecteer optie                           |${zender}            |in dropdown           |Zenders                               |
-|wait for visible                                          |Gezocht naar: ${zender}                                                            |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                              |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                               |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                    |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                      |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                              |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                               |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                        |
-|Npo poms Hoofdscherm Log uit                                                                                                                  |
+|script                                                                                                                          |
+|Open Npo poms website                                                                                                           |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                             |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                  |
+|Npo poms Zoeken Selecteer optie                         |${omroep}|in dropdown           |Omroepen                              |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${omroep}|klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                  |
+|ensure                                                  |value    |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
+|Npo poms Zoeken Open eerste object                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                  |
+|Npo poms Zoeken Selecteer optie                         |${zender}|in dropdown           |Zenders                               |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|${zender}|klaar is                                                     |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                  |
+|ensure                                                  |value    |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1|
+|Npo poms Zoeken Open eerste object                                                                                              |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                          |
+|Npo poms Hoofdscherm Log uit                                                                                                    |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa14-SpomsZoek5.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa14-SpomsZoek5.wiki
@@ -9,10 +9,6 @@ Test
 !define avtype {Video}
 !define persoon {Paul Koster}
 
-!define datumEnPersoon1 {!-uitzend-/sorteerdatum:
-vanaf: $vorigeMaand
-tot en met:-!}
-
 !define datumEnPersoon2 {aangemaakt door:}
 
 !define datumvandaag {!today (dd-MM-yyyy)}
@@ -25,43 +21,33 @@ tot en met:-!}
 |ensure  |is visible on page                             |xpath=//span[normalize-space(.)='uitzend-/sorteerdatum:']/following::a[normalize-space(.)='tot en met: @eind']|
 *!
 
-|script                                                                                                                                                                                         |
-|Open Npo poms website                                                                                                                                                                          |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                                                            |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                                                                               |
-|click                                                     |Datum & Persoon                                                                                                                     |
-|click                                                     |Afgelopen maand                                                                                                                     |
-|$vorigeMaand=                                             |decrease today with months |1                                     |with format             |dd-MM-yyyy              |with local |nl |
-|Npo poms Zoeken Check tekstveld                           |van:                       |heeft waarde                          |$vorigeMaand                                                     |
-|Npo poms Zoeken Check tekstveld                           |t/m                        |heeft waarde                          |${datumvandaag}                                                  |
-|click                                                     |Zoek                                                                                                                                |
-|Controleer weergegeven datumrange voor zoeken;            |$vorigeMaand               |${datumvandaag}                       |                                                                 |
-|wait for visible                                          |Gezocht naar: uitzend-/sorteerdatum: vanaf $vorigeMaand tot en met ${datumvandaag}                                                  |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                                                                               |
-|ensure                                                    |value                      |$aantalZoekresultaten2                |is smaller than         |$aantalZoekresultaten1                  |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                                                                                |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                                                                 |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                                                                     |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject      |geopend                                                                                                 |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                                                                               |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                                                                                |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                         |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                         |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                                                                               |
-|click                                                     |Datum & Persoon                                                                                                                     |
-|click                                                     |Aangemaakt door                                                                                                                     |
-|Npo poms Zoeken Selecteer persoon                         |${persoon}                                                                                                                          |
-|click                                                     |Zoek                                                                                                                                |
-|Npo poms Zoeken Check optie                               |${datumEnPersoon2}         |is                                    |${persoon}              |geselecteerd in dropdown|Datum & Persoon|
-|wait for visible                                          |Gezocht naar: gemaakt door: ${persoon}                                                                                              |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                                                                               |
-|ensure                                                    |value                      |$aantalZoekresultaten2                |is smaller than         |$aantalZoekresultaten1                  |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                                                                                |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                                                                 |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                                                                     |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject      |geopend                                                                                                 |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                                                                               |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                                                                                |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                         |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                         |
-|Npo poms Hoofdscherm Log uit                                                                                                                                                                   |
+|script                                                                                                                                                                                                       |
+|Open Npo poms website                                                                                                                                                                                        |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                                                                          |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                                                                               |
+|click                                                   |Datum & Persoon                                                                                                                                     |
+|click                                                   |Afgelopen maand                                                                                                                                     |
+|$vorigeMaand=                                           |decrease today with months                                          |1                     |with format    |dd-MM-yyyy              |with local |nl |
+|Npo poms Zoeken Check tekstveld                         |van:                                                                |heeft waarde          |$vorigeMaand                                            |
+|Npo poms Zoeken Check tekstveld                         |t/m                                                                 |heeft waarde          |${datumvandaag}                                         |
+|click                                                   |Zoek                                                                                                                                                |
+|Controleer weergegeven datumrange voor zoeken;          |$vorigeMaand                                                        |${datumvandaag}       |                                                        |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|uitzend-/sorteerdatum: vanaf $vorigeMaand tot en met ${datumvandaag}|klaar is                                                                       |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                                                                               |
+|ensure                                                  |value                                                               |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1                  |
+|Npo poms Zoeken Open eerste object                                                                                                                                                                           |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                                       |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                                       |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                                                                               |
+|click                                                   |Datum & Persoon                                                                                                                                     |
+|click                                                   |Aangemaakt door                                                                                                                                     |
+|Npo poms Zoeken Selecteer persoon                       |${persoon}                                                                                                                                          |
+|click                                                   |Zoek                                                                                                                                                |
+|Npo poms Zoeken Check optie                             |${datumEnPersoon2}                                                  |is                    |${persoon}     |geselecteerd in dropdown|Datum & Persoon|
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|gemaakt door: ${persoon}                                            |klaar is                                                                       |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                                                                               |
+|ensure                                                  |value                                                               |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1                  |
+|Npo poms Zoeken Open eerste object                                                                                                                                                                           |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                                       |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                                       |
+|Npo poms Hoofdscherm Log uit                                                                                                                                                                                 |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa15-SpomsZoek6.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa15-SpomsZoek6.wiki
@@ -4,18 +4,14 @@ Test
 ---
 !define MIDVALUE {!-POMS_NTR_157704-!}
 
-|script                                                                                      |
-|Open Npo poms website                                                                       |
-|Npo poms Inlogscherm Log in met npo                                                         |
-|click                                                     |Zoeken                           |
-|Npo poms Zoeken Vul                                       |${MIDVALUE}          |in zoekveld|
-|Npo poms Zoeken Druk knop                                 |Zoeken                           |
-|Npo poms Zoeken Check aantal zoekresultaten               |1                                |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject             |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject              |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                  |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend    |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject            |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject             |
-|Npo poms Hoofdscherm Sluit laatste tab                                                      |
-|Npo poms Hoofdscherm Log uit                                                                |
+|script                                                                            |
+|Open Npo poms website                                                             |
+|Npo poms Inlogscherm Log in met npo                                               |
+|click                                                   |Zoeken                   |
+|Npo poms Zoeken Vul                                     |${MIDVALUE}  |in zoekveld|
+|Npo poms Zoeken Druk knop                               |Zoeken                   |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${MIDVALUE}'|klaar is   |
+|Npo poms Zoeken Check aantal zoekresultaten             |1                        |
+|Npo poms Zoeken Open eerste object                                                |
+|Npo poms Hoofdscherm Sluit laatste tab                                            |
+|Npo poms Hoofdscherm Log uit                                                      |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa17-SpomsZoek8.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPomsSuite/TestScripts/DesktopDevice/Zoeken/NpoTa17-SpomsZoek8.wiki
@@ -11,27 +11,22 @@ Test
 
 *!
 
-|script                                                                                                                                                          |
-|Open Npo poms website                                                                                                                                           |
-|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                             |
-|Npo poms Zoeken Vul                                       |${zoekopdracht}      |in zoekveld                                                                    |
-|Npo poms Zoeken Druk knop                                 |Zoeken                                                                                               |
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}'                                                                      |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten1                                                                                |
-|click                                                     |Datum & Persoon                                                                                      |
-|click                                                     |Gewijzigd door                                                                                       |
-|Npo poms Zoeken Selecteer persoon                         |${persoon}                                                                                           |
-|click                                                     |Zoek                                                                                                 |
-|Npo poms Zoeken Check optie                               |${datumEnPersoon}    |is                    |${persoon}     |geselecteerd in dropdown|Datum & Persoon|
-|wait for visible                                          |Gezocht naar: '${zoekopdracht}' in gewijzigd door: ${persoon}                                        |
-|Npo poms Zoeken Sla aantal zoekresultaten op in var       |aantalZoekresultaten2                                                                                |
-|ensure                                                    |value                |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1                  |
-|Npo poms Zoeken Sla hoofdtitel van eerste object op in var|titelVanEersteObject                                                                                 |
-|Npo poms Zoeken Sla type van eerste object op in var      |typeVanEersteObject                                                                                  |
-|Npo poms Zoeken Dubbelklik op hoofdtitel van eerste object                                                                                                      |
-|Npo poms Hoofdscherm Wacht tot tabblad                    |$titelVanEersteObject|geopend                                                                        |
-|Npo poms Hoofdscherm Check titel van laatste tab          |$titelVanEersteObject                                                                                |
-|Npo poms Hoofdscherm Check subtitel van laatste tab       |$typeVanEersteObject                                                                                 |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                          |
-|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                          |
-|Npo poms Hoofdscherm Log uit                                                                                                                                    |
+|script                                                                                                                                                                                  |
+|Open Npo poms website                                                                                                                                                                   |
+|Npo poms Inlogscherm Log in met standaard-gebruiker                                                                                                                                     |
+|Npo poms Zoeken Vul                                     |${zoekopdracht}                                |in zoekveld                                                                    |
+|Npo poms Zoeken Druk knop                               |Zoeken                                                                                                                         |
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}'                              |klaar is                                                                       |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten1                                                                                                          |
+|click                                                   |Datum & Persoon                                                                                                                |
+|click                                                   |Gewijzigd door                                                                                                                 |
+|Npo poms Zoeken Selecteer persoon                       |${persoon}                                                                                                                     |
+|click                                                   |Zoek                                                                                                                           |
+|Npo poms Zoeken Check optie                             |${datumEnPersoon}                              |is                    |${persoon}     |geselecteerd in dropdown|Datum & Persoon|
+|Npo poms Zoeken Wacht tot zoekopdracht met Gezocht naar:|'${zoekopdracht}' in gewijzigd door: ${persoon}|klaar is                                                                       |
+|Npo poms Zoeken Sla aantal zoekresultaten op in var     |aantalZoekresultaten2                                                                                                          |
+|ensure                                                  |value                                          |$aantalZoekresultaten2|is smaller than|$aantalZoekresultaten1                  |
+|Npo poms Zoeken Open eerste object                                                                                                                                                      |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                  |
+|Npo poms Hoofdscherm Sluit laatste tab                                                                                                                                                  |
+|Npo poms Hoofdscherm Log uit                                                                                                                                                            |


### PR DESCRIPTION
Toelichting: bij het openen van zoekresultaten werd veelvuldig gecheckt
op de titel van de geopende tab. Dit gaf soms onterechte failures, omdat
de titel van een object in de zoekresultaten niet altijd volledig wordt
weergegeven. Deze refactor vervangt deze check door een check op een
geopende tab met de juiste MID. Ook is meteen van de gelegenheid gebruik
gemaakt om de hele actie met alle checks in een scenario te stoppen.

Daarnaast is |wait for visible|Gezocht naar: (...)| overal vervangen door
een scenario dat wacht tot de resultaten ook daadwerkelijk geladen zijn.

Zie ook https://specialisterren.atlassian.net/browse/NPOTA-102