### PR TITLE
Refactor backend API tests: remove |show| workaround

### DIFF
--- a/poms-functional-tests-fitnesse/src/main/java/nl/specialisterren/fitnesse/fixture/slim/HybridXmlHttpTest.java
+++ b/poms-functional-tests-fitnesse/src/main/java/nl/specialisterren/fitnesse/fixture/slim/HybridXmlHttpTest.java
@@ -1,0 +1,42 @@
+package nl.specialisterren.fitnesse.fixture.slim;
+
+import nl.hsac.fitnesse.fixture.slim.XmlHttpTest;
+
+/**
+ * Extension of XmlHttpTest that adds functionality to allow non-xml responses
+ *
+ * XmlHttpTest returns false on getFrom, postTo and so on when the response
+ * has a body and that body is not xml. This is very inconvenient when testing
+ * APIs that return responses of various types. Therefore, this class allows
+ * turning that behavior on and off.
+ *
+ * Note that xPath and all related functions still throw an exception if the
+ * response body is not xml. Therefore, as long as you run at least 1 XPath
+ * after a request that should return an xml response, your test will still
+ * fail on receiving a non-xml response, even if you called
+ * acceptNonXmlResponsesInSubsequentRequests.
+ */
+public class HybridXmlHttpTest extends XmlHttpTest {
+    protected boolean acceptNonXmlResponses = false;
+
+    public void acceptNonXmlResponsesInSubsequentRequests() {
+        acceptNonXmlResponses = true;
+    }
+
+    public void rejectNonXmlResponsesInSubsequentRequests() {
+        acceptNonXmlResponses = false;
+    }
+
+    @Override
+    public boolean responseIsValid() {
+        if (acceptNonXmlResponses) {
+            // Return true or false as HttpTest would if throwExceptionOnHttpRequestFailure were false
+            // We rarely enable those exceptions anyway, and this way we avoid relying on implementation details,
+            // greatly reducing the probability that a HSAC update will break this override
+            int statusCode = responseStatus();
+            return !(statusCode < 100 || (statusCode >= 400 && statusCode <= 599));
+        } else {
+            return super.responseIsValid();
+        }
+    }
+}

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/ScenarioLibrary.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/ScenarioLibrary.wiki
@@ -1,2 +1,3 @@
 !include -c ScenarioLibrary.FrontendApi
+!include -c ScenarioLibrary.BackendApi
 !include -c ScenarioLibrary.Gui

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/ScenarioLibrary/BackendApi.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/ScenarioLibrary/BackendApi.wiki
@@ -1,0 +1,7 @@
+|scenario                       |repeat get from                |url                              |until response status is              |responseStatus              |
+|note                           |Ignore the result of the initial request call so the test doesn't fail on it. We're only interested in the result of the repeat until|
+|$ignoredResult=                |get from                       |@url                                                                                                 |
+|repeat until response status is|@responseStatus                                                                                                                      |
+|$repeatCount=                  |repeat count                                                                                                                         |
+|$timeSpentRepeating=           |time spent repeating                                                                                                                 |
+|$timeSpentRepeating=           |format timestamp               |$timeSpentRepeating              |as                                    |m:ss                        |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityId.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityId.wiki
@@ -3,6 +3,6 @@ Help: NPOAPI-95
 Suites: RG
 Test
 ---
-|script                                                            |
-|show |delete         |${urlBackendApi}/media/media/WO_VPRO_3338447|
-|check|response status|202                                         |
+|script                                             |
+|delete|${urlBackendApi}/media/media/WO_VPRO_3338447|
+|check |response status             |202            |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityIdLocationLocationId.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityIdLocationLocationId.wiki
@@ -25,20 +25,17 @@ Test
 </program>
 }}} }
 *!
-|script                                                                                                                                 |
-|show                           |post            |${body}                           |to  |${urlBackendApi}/media/media?owner=BROADCASTER|
-|$id=                           |response                                                                                               |
-|show                           |get from        |${urlBackendApi}/media/media/$id/locations?owner=BROADCASTER                          |
-|repeat until response status is|200                                                                                                    |
-|$repeatCount=                  |repeat count                                                                                           |
-|$timeSpentRepeating=           |time spent repeating                                                                                   |
-|$timeSpentRepeating=           |format timestamp|$timeSpentRepeating               |as  |m:ss                                          |
-|check                          |xPath           |count(/collection/update:location)|1                                                  |
-|$urn=                          |xPath           |/collection/update:location/@urn                                                      |
-|$locationId=                   |extract string  |$urn                              |from|^urn:vpro:media:location:(\d+)$ |using group|1|
-|show                           |delete          |${urlBackendApi}/media/media/$id/location/$locationId                                 |
-|check                          |response status |202                                                                                   |
-|check                          |response        |Location delete submitted to $id.                                                     |
-|get from                       |${urlBackendApi}/media/media/$id/locations?owner=BROADCASTER                                           |
-|check                          |xPath           |count(/collection/update:location)|0                                                  |
-|show                           |delete          |${urlBackendApi}/media/media/$id                                                      |
+
+|script                                                                                                                                                            |
+|post           |${body}                                                     |to                                |${urlBackendApi}/media/media?owner=BROADCASTER    |
+|$id=           |response                                                                                                                                          |
+|repeat get from|${urlBackendApi}/media/media/$id/locations?owner=BROADCASTER|until response status is          |200                                               |
+|check          |xPath                                                       |count(/collection/update:location)|1                                                 |
+|$urn=          |xPath                                                       |/collection/update:location/@urn                                                     |
+|$locationId=   |extract string                                              |$urn                              |from|^urn:vpro:media:location:(\d+)$|using group|1|
+|delete         |${urlBackendApi}/media/media/$id/location/$locationId                                                                                             |
+|check          |response status                                             |202                                                                                  |
+|check          |response                                                    |Location delete submitted to $id.                                                    |
+|get from       |${urlBackendApi}/media/media/$id/locations?owner=BROADCASTER                                                                                      |
+|check          |xPath                                                       |count(/collection/update:location)|0                                                 |
+|delete         |${urlBackendApi}/media/media/$id                                                                                                                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityIdMemberOfOwner.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaEntityIdMemberOfOwner.wiki
@@ -3,6 +3,6 @@ Help: NPOAPI-106
 Suites: RG
 Test
 ---
-|script                                                                                         |
-|show |delete         |${urlBackendApi}/media/media/POMS_VPRO_3339238/memberOf/POMS_VPRO_3339239|
-|check|response status|202                                                                      |
+|script                                                                          |
+|delete|${urlBackendApi}/media/media/POMS_VPRO_3339238/memberOf/POMS_VPRO_3339239|
+|check |response status                           |202                           |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaProgramIdSegmentSegmentId.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaProgramIdSegmentSegmentId.wiki
@@ -23,21 +23,18 @@ Test
 </program>
 }}} }
 *!
-|script                                                                                                                                                       |
-|show                           |post            |${body}                                                 |to|${urlBackendApi}/media/program?owner=BROADCASTER|
-|$itemId=                       |response                                                                                                                     |
-|show                           |get from        |${urlBackendApi}/media/program/$itemId/full                                                                 |
-|repeat until response status is|200                                                                                                                          |
-|$repeatCount=                  |repeat count                                                                                                                 |
-|$timeSpentRepeating=           |time spent repeating                                                                                                         |
-|$timeSpentRepeating=           |format timestamp|$timeSpentRepeating                                     |as|m:ss                                            |
-|$segmentId=                    |xPath           |/media:program/media:segments/media:segment[1]/@midRef                                                      |
-|show                           |delete          |${urlBackendApi}/media/program/$itemId/segment/$segmentId                                                   |
-|check                          |response status |202                                                                                                         |
-|check                          |response        |Removed accepted for $segmentId of $itemId.                                                                 |
-|get from                       |${urlBackendApi}/media/program/$itemId/full                                                                                  |
-|check                          |xPath           |/media:program/media:segments/media:segment[1]/@workflow|FOR DELETION                                       |
-|show                           |delete          |${urlBackendApi}/media/program/$itemId                                                                      |
-|get from                       |${urlBackendApi}/media/program/$itemId/full                                                                                  |
-|check                          |xPath           |/media:program/media:segments/media:segment[1]/@workflow|FOR DELETION                                       |
-|check                          |xPath           |/media:program/@workflow                                |FOR DELETION                                       |
+
+|script                                                                                                                                                               |
+|post           |${body}                                    |to                                                      |${urlBackendApi}/media/program?owner=BROADCASTER|
+|$itemId=       |response                                                                                                                                             |
+|repeat get from|${urlBackendApi}/media/program/$itemId/full|until response status is                                |200                                             |
+|$segmentId=    |xPath                                      |/media:program/media:segments/media:segment[1]/@midRef                                                   |
+|delete         |${urlBackendApi}/media/program/$itemId/segment/$segmentId                                                                                            |
+|check          |response status                            |202                                                                                                      |
+|check          |response                                   |Removed accepted for $segmentId of $itemId.                                                              |
+|get from       |${urlBackendApi}/media/program/$itemId/full                                                                                                          |
+|check          |xPath                                      |/media:program/media:segments/media:segment[1]/@workflow|FOR DELETION                                    |
+|delete         |${urlBackendApi}/media/program/$itemId                                                                                                               |
+|get from       |${urlBackendApi}/media/program/$itemId/full                                                                                                          |
+|check          |xPath                                      |/media:program/media:segments/media:segment[1]/@workflow|FOR DELETION                                    |
+|check          |xPath                                      |/media:program/@workflow                                |FOR DELETION                                    |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaSubtitlesMidLanguageType.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/DeleteMediaSubtitlesMidLanguageType.wiki
@@ -6,7 +6,8 @@ Test
 !*> Test-specific items
 !define mid {POMS_VPRO_3339239}
 *!
+
 |script                                                                  |
-|show |delete         |${urlBackendApi}/media/subtitles/${mid}/nl/CAPTION|
-|check|response status|202                                               |
-|check|response       |Subtitles deletion accepted for ${mid}	CAPTION	nl |
+|delete|${urlBackendApi}/media/subtitles/${mid}/nl/CAPTION               |
+|check |response status|202                                              |
+|check |response       |Subtitles deletion accepted for ${mid}	CAPTION	nl|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaExistsMid.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaExistsMid.wiki
@@ -4,11 +4,13 @@ Suites: DV
 Test
 ---
 !*> Test-specific items
-|table template|Check response                                      |
-|show          |get from       |${urlBackendApi}/media/exists/@{mid}|
-|check         |response       |@{responseBody}                     |
-|check         |response status|@{responseCode}                     |
+|table template |Check response                                                                         |
+|note           |Ignore the result of the get from so the test doesn't fail on the expected 404 response|
+|$ignoredResult=|get from                         |${urlBackendApi}/media/exists/@{mid}                 |
+|check          |response                         |@{responseBody}                                      |
+|check          |response status                  |@{responseCode}                                      |
 *!
+
 |Check response                            |
 |mid           |response body|response code|
 |VARA_101372600|true         |200          |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaGroupIdEpisodesFull.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaGroupIdEpisodesFull.wiki
@@ -7,6 +7,7 @@ Test
 !define m {!-<li>-!ROGE!-</li>-!}
 !define matches {!-<div><ul>-!${m}${m}${m}${m}${m}!-</ul></div>-!}
 *!
+
 |script                                                                                           |
 |get from|${urlBackendApi}/media/group/SREGIOOG_4DAAGSEJOURNAAL2012/episodes/full?order=ASC       |
 |check   |xPath            |count(/search:list/search:item)                            |5         |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaProgramIdEpisodeOfs.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaProgramIdEpisodeOfs.wiki
@@ -6,6 +6,7 @@ Test
 !*> Test-specific items
 !define id {POW_00457214}
 *!
+
 |script                                                  |
 |get from|${urlBackendApi}/media/program/${id}/episodeOfs|
 |check   |xPath  |/update:list/update:item |POW_00457191 |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaStreamingstatusMid.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaStreamingstatusMid.wiki
@@ -9,6 +9,7 @@ Test
 |check         |xPath|/media:streamingStatus/@withDrm   |@{with_drm}   |
 |check         |xPath|/media:streamingStatus/@withoutDrm|@{without_drm}|
 *!
+
 |Check streaming status             |
 |mid           |with_drm|without_drm|
 |VPWON_1272435 |ONLINE  |OFFLINE    |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaSubtitlesMidLanguageType.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/GetMediaSubtitlesMidLanguageType.wiki
@@ -10,10 +10,9 @@ Regex components for verifying [[WebVTT][https://developer.mozilla.org/en-US/doc
 !define timing {!-\d{2}:\d{2}:\d{2}\.\d{3} --> \d{2}:\d{2}:\d{2}\.\d{3}\n-!}
 !define cue {(.+\n)+\n}
 
-|scenario|check subtitle |mid       |counts      |count      |sections      |
-|show    |get from       |${urlBackendApi}/media/subtitles/@{mid}/nl/CAPTION|
-|check   |response status|200                                               |
-|check   |response       |=~/^${header}(${id}${timing}${cue}){@count}$/     |
+|scenario|check subtitle|mid     |counts     |count     |sections     |
+|get from|${urlBackendApi}/media/subtitles/@{mid}/nl/CAPTION          |
+|check   |response      |=~/^${header}(${id}${timing}${cue}){@count}$/|
 *!
 
 |script                                         |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntity.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntity.wiki
@@ -24,23 +24,21 @@ Test
 *!
 
 !4 Create
-|script                                                                         |
-|show |post           |${body}|to|${urlBackendApi}/media/media?owner=BROADCASTER|
-|check|response status|202                                                      |
-|check|response       |=~/^POMS_NPO_\d{7}$/                                     |
-|$mid=|response                                                                 |
+|script                                                                 |
+|post |${body}        |to|${urlBackendApi}/media/media?owner=BROADCASTER|
+|check|response status|202                                              |
+|check|response       |=~/^POMS_NPO_\d{7}$/                             |
+|$mid=|response                                                         |
 
 !4 Read (verify creation)
-|script                                                                    |
-|show                           |get from|${urlBackendApi}/media/media/$mid|
-|repeat until response status is|200                                       |
-|show                           |time spent repeating                      |
-|check                          |xPath   |/update:program/@mid    |$mid    |
+|script                                                                         |
+|repeat get from|${urlBackendApi}/media/media/$mid|until response status is|200 |
+|check          |xPath                            |/update:program/@mid    |$mid|
 
 !4 Delete
-|script                                                 |
-|show |delete         |${urlBackendApi}/media/media/$mid|
-|check|response status|202                              |
+|script                                  |
+|delete|${urlBackendApi}/media/media/$mid|
+|check |response status       |202       |
 
 !4 Read (verify deletion)
 |script                                              |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdImage.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdImage.wiki
@@ -16,6 +16,7 @@ Test
 </image>
 }}} }
 *!
-|script                                                                                     |
-|show |post           |${body}|to|${urlBackendApi}/media/media/${id}/image?owner=BROADCASTER|
-|check|response status|202                                                                  |
+
+|script                                                                             |
+|post |${body}        |to|${urlBackendApi}/media/media/${id}/image?owner=BROADCASTER|
+|check|response status|202                                                          |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdLocation.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdLocation.wiki
@@ -16,7 +16,8 @@ Test
 </location>
 }}} }
 *!
-|script                                                                      |
-|show |post           |${body}|to|${urlBackendApi}/media/media/${id}/location|
-|check|response status|202                                                   |
-|check|response       |Location accepted for ${id}.                          |
+
+|script                                                              |
+|post |${body}        |to|${urlBackendApi}/media/media/${id}/location|
+|check|response status|202                                           |
+|check|response       |Location accepted for ${id}.                  |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdMemberOf.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdMemberOf.wiki
@@ -10,6 +10,7 @@ Test
 <memberRef xmlns="urn:vpro:media:update:2009" position="1" highlighted="true">${id}</memberRef>
 }}} }
 *!
-|script                                                                      |
-|show |post           |${body}|to|${urlBackendApi}/media/media/${id}/memberOf|
-|check|response status|202                                                   |
+
+|script                                                              |
+|post |${body}        |to|${urlBackendApi}/media/media/${id}/memberOf|
+|check|response status|202                                           |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdPredictions.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdPredictions.wiki
@@ -12,6 +12,7 @@ Test
 </collection>
 }}} }
 *!
-|script                                                                         |
-|show |post           |${body}|to|${urlBackendApi}/media/media/${id}/predictions|
-|check|response status|204                                                      |
+
+|script                                                                 |
+|post |${body}        |to|${urlBackendApi}/media/media/${id}/predictions|
+|check|response status|204                                              |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdPredictionsPlatform.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityIdPredictionsPlatform.wiki
@@ -12,6 +12,7 @@ Test
 </prediction>
 }}} }
 *!
-|script                                                                                     |
-|show |post           |${body}|to|${urlBackendApi}/media/media/${id}/predictions/INTERNETVOD|
-|check|response status|204                                                                  |
+
+|script                                                                             |
+|post |${body}        |to|${urlBackendApi}/media/media/${id}/predictions/INTERNETVOD|
+|check|response status|204                                                          |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityMidItemize.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityMidItemize.wiki
@@ -13,8 +13,9 @@ Test
 </itemize>
 }}} }
 *!
+
 |script                                                                                                              |
-|show |post           |${body}                              |to     |${urlBackendApi}/media/media/${mid}/itemize     |
+|post |${body}        |to                                   |${urlBackendApi}/media/media/${mid}/itemize             |
 |check|response status|200                                                                                           |
 |check|xPath          |/update:itemizeResponse/update:result|${urlBackendApi}!-/nep/-!${mid}__000000000-000010000.mp4|
 |check|xPath          |/update:itemizeResponse/@success     |true                                                    |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityMidTranscode.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaEntityMidTranscode.wiki
@@ -14,7 +14,8 @@ Test
 </transcode>
 }}} }
 *!
+
 |script                                                                                  |
-|show |post           |${body}    |to   |${urlBackendApi}/media/media/${mid}/transcode   |
+|post |${body}        |to         |${urlBackendApi}/media/media/${mid}/transcode         |
 |check|response status|202                                                               |
 |check|response       |Transcoding job accepted for mid ${mid} errors are mailed to: null|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaProgramIdEpisodeOf.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaProgramIdEpisodeOf.wiki
@@ -10,6 +10,7 @@ Test
 <memberRef xmlns="urn:vpro:media:update:2009" position="1" highlighted="true">${id}</memberRef>
 }}} }
 *!
-|script                                                                         |
-|show |post           |${body}|to|${urlBackendApi}/media/program/${id}/episodeOf|
-|check|response status|202                                                      |
+
+|script                                                                 |
+|post |${body}        |to|${urlBackendApi}/media/program/${id}/episodeOf|
+|check|response status|202                                              |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaSubtitlesMidLanguageType.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaSubtitlesMidLanguageType.wiki
@@ -39,6 +39,6 @@ Test
 
 |script                                                                                                     |
 |set content type|text/vtt                                                                                  |
-|show            |post           |${body}     |to    |${urlBackendApi}/media/subtitles/${mid}/nl/CAPTION    |
+|post            |${body}        |to           |${urlBackendApi}/media/subtitles/${mid}/nl/CAPTION          |
 |check           |response status|202                                                                       |
 |check           |response       |Subtitles (4 cues, 569 bytes) provisionally accepted for ${mid}	CAPTION	nl|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaTranscode.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PostMediaTranscode.wiki
@@ -14,7 +14,8 @@ Test
 </transcode>
 }}} }
 *!
+
 |script                                                                                  |
-|show |post           |${body}        |to        |${urlBackendApi}/media/transcode       |
+|post |${body}        |to                |${urlBackendApi}/media/transcode               |
 |check|response status|202                                                               |
 |check|response       |Transcoding job accepted for mid ${mid} errors are mailed to: null|

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PutMediaEntityIdMembers.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/Media/PutMediaEntityIdMembers.wiki
@@ -15,19 +15,20 @@ Test
 !define responseStatus {202}
 !define response {Move accepted for ${id}.}
 *!
-|script                                                                                                                    |
-|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                                 |
-|$mid1=  |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid                                              |
-|$mid2=  |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid                                              |
-|show    |put            |${body}                                            |to|${urlBackendApi}/media/media/${id}/members|
-|check   |response status|${responseStatus}                                                                                |
-|check   |response       |${response}                                                                                      |
-|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                                 |
-|check   |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid|$mid2                                        |
-|check   |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid|$mid1                                        |
-|show    |put            |${body}                                            |to|${urlBackendApi}/media/media/${id}/members|
-|check   |response status|${responseStatus}                                                                                |
-|check   |response       |${response}                                                                                      |
-|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                                 |
-|check   |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid|$mid1                                        |
-|check   |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid|$mid2                                        |
+
+|script                                                                                                                 |
+|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                              |
+|$mid1=  |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid                                           |
+|$mid2=  |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid                                           |
+|put     |${body}        |to                                                 |${urlBackendApi}/media/media/${id}/members|
+|check   |response status|${responseStatus}                                                                             |
+|check   |response       |${response}                                                                                   |
+|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                              |
+|check   |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid|$mid2                                     |
+|check   |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid|$mid1                                     |
+|put     |${body}        |to                                                 |${urlBackendApi}/media/media/${id}/members|
+|check   |response status|${responseStatus}                                                                             |
+|check   |response       |${response}                                                                                   |
+|get from|${urlBackendApi}/media/media/${id}/members?max=2                                                              |
+|check   |xPath          |/update:list/update:item[1]/update:mediaUpdate/@mid|$mid1                                     |
+|check   |xPath          |/update:list/update:item[2]/update:mediaUpdate/@mid|$mid2                                     |

--- a/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/SetUp.wiki
+++ b/poms-functional-tests-fitnesse/wiki/FitNesseRoot/NpoPoms/TestScripts/Api/Backend/SetUp.wiki
@@ -1,6 +1,9 @@
-|script                                 |xml http test                                                               |
-|set basic authorization header for user|$backEndApiUsername        |and password        |$backEndApiPassword        |
-|note                                   |application/x-www-form-urlencoded is the http test default, NPO API expects:|
-|set content type                       |application/xml; charset=UTF-8                                              |
-|set repeat interval to                 |10000                      |milliseconds                                    |
-|repeat at most                         |30                         |times                                           |
+!note The backend API returns both xml and non-xml responses, so use a custom hybrid class
+!note This way, we retain access to all methods of xml http test, but don't have to work around tests failing on non-xml responses
+|script                                 |hybrid xml http test                                                  |
+|accept non-xml responses in subsequent requests                                                               |
+|set basic authorization header for user|$backEndApiUsername      |and password      |$backEndApiPassword      |
+|note                                   |text/xml; charset=UTF-8 is the xml http test default, NPO API expects:|
+|set content type                       |application/xml; charset=UTF-8                                        |
+|set repeat interval to                 |10000                    |milliseconds                                |
+|repeat at most                         |30                       |times                                       |


### PR DESCRIPTION
This commit adds the HybridXmlHttpTest class to allow using XmlHttpTest's
methods without |get from|, |post to| etcetera failing on non-xml response
bodies. Non-xml responses are allowed everywhere in all backend API tests
for now, but that may be locally undone by calling |reject non-xml responses
in subsequent requests|. Note that |xPath| and related functions will still
throw an exception on non-xml responses, so tests will still fail where
appropriate.

The |show| workaround has been removed everywhere. In places where a
workaround is still needed because the request call may return false due to
an expected 4xx response code, comments have been added and |show| has been
replaced with a more explicit |$ignoredResult=|. Also, these workarounds
are contained in scenarios or table templates to hide the additional
complexity from immediate view. Hopefully this will make things more
readable for people less experienced with the ins and outs of FitNesse and
HSAC's HttpTest fixtures.

Additionally, some newline consistency fixes have been applied.